### PR TITLE
Add support for new trajectory format with entries array

### DIFF
--- a/src/components/RunDetails.tsx
+++ b/src/components/RunDetails.tsx
@@ -46,11 +46,24 @@ const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialConten
 
   // Create a reference for timelineEntries for use in multiple places
   const getTimelineEntries = useCallback(() => {
-    // Check if this is an OpenHands trajectory
-    if (artifactContent?.content?.trajectory) {
-      return convertOpenHandsTrajectory(artifactContent.content.trajectory);
+    try {
+      // Check if this is an OpenHands trajectory
+      if (artifactContent?.content?.trajectory) {
+        return convertOpenHandsTrajectory(artifactContent.content.trajectory);
+      }
+      return artifactContent?.content?.history || artifactContent?.content?.jsonlHistory || [];
+    } catch (error) {
+      console.error('Failed to convert trajectory:', error);
+      return [{
+        type: 'error',
+        timestamp: new Date().toISOString(),
+        title: 'Error Processing Trajectory',
+        content: `Failed to process trajectory: ${error instanceof Error ? error.message : 'Unknown error'}. The trajectory visualizer accepts the following formats:\n\n1. Array of events with action, args, timestamp, etc.\n2. Object with "entries" array containing events\n3. Object with "test_result.git_patch" containing a git patch`,
+        actorType: 'System',
+        command: '',
+        path: ''
+      }];
     }
-    return artifactContent?.content?.history || artifactContent?.content?.jsonlHistory || [];
   }, [artifactContent]);
 
   // Direct keyboard navigation for timeline steps

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -38,17 +38,16 @@ export const Timeline: React.FC<TimelineProps> = ({
     <div className="h-full py-1 px-2">
       <div ref={timelineContainerRef}>
         {/* Empty state */}
-        {entries.length <= 1 && (
+        {entries.length === 0 && (
           <div className="p-4 text-center text-gray-500">
             No timeline entries available
           </div>
         )}
 
-        {/* Timeline entries - Skip the first step (index 0) */}
+        {/* Timeline entries */}
         <div>
-          {entries.slice(1).map((entry, index) => {
-            // Add 1 to index since we're slicing from index 1
-            const realIndex = index + 1;
+          {entries.map((entry, index) => {
+            const realIndex = index;
             return (
               <div
                 key={realIndex}

--- a/src/components/upload/__tests__/UploadTrajectory.test.tsx
+++ b/src/components/upload/__tests__/UploadTrajectory.test.tsx
@@ -29,7 +29,7 @@ describe('UploadTrajectory', () => {
     expect(screen.getByText(/drag and drop a trajectory file here/i)).toBeInTheDocument();
   });
 
-  it('handles file upload', async () => {
+  it('handles old format correctly', async () => {
     render(<UploadTrajectory onUpload={mockOnUpload} />);
 
     const file = new File([
@@ -57,6 +57,50 @@ describe('UploadTrajectory', () => {
               args: { command: 'ls' }
             }
           ]
+        }
+      });
+    });
+  });
+
+  it('handles new format correctly', async () => {
+    render(<UploadTrajectory onUpload={mockOnUpload} />);
+
+    const newFormatData = {
+      entries: [
+        {
+          id: 1,
+          timestamp: '2025-03-07T17:45:00.000Z',
+          type: 'message',
+          content: 'Hello, I need help with my code.',
+          actorType: 'User'
+        },
+        {
+          id: 2,
+          timestamp: '2025-03-07T17:45:10.000Z',
+          type: 'thought',
+          content: 'Let me analyze the code and identify potential issues.',
+          actorType: 'Assistant'
+        }
+      ]
+    };
+
+    const file = new File(
+      [JSON.stringify(newFormatData)],
+      'trajectory.json',
+      { type: 'application/json' }
+    );
+
+    const dropzone = screen.getByText(/drag and drop a trajectory file here/i).parentElement!.parentElement!;
+    const dropEvent = createDropEvent([file]);
+
+    await act(async () => {
+      fireEvent.drop(dropzone, dropEvent);
+    });
+
+    await waitFor(() => {
+      expect(mockOnUpload).toHaveBeenCalledWith({
+        content: {
+          trajectory: newFormatData
         }
       });
     });

--- a/src/utils/__tests__/openhands-converter.test.ts
+++ b/src/utils/__tests__/openhands-converter.test.ts
@@ -259,6 +259,54 @@ describe('OpenHands Trajectory Converter', () => {
     });
   });
 
+  it('should handle new format with entries array', () => {
+    const newFormatData = {
+      entries: [
+        {
+          id: 1,
+          timestamp: '2025-03-07T17:45:00.000Z',
+          type: 'message',
+          content: 'Hello, I need help with my code.',
+          source: 'user',
+          observation: 'user_message'
+        },
+        {
+          id: 2,
+          timestamp: '2025-03-07T17:45:10.000Z',
+          type: 'thought',
+          content: 'Let me analyze the code and identify potential issues.',
+          source: 'assistant',
+          observation: 'assistant_message'
+        }
+      ]
+    };
+
+    const result = convertOpenHandsTrajectory(newFormatData);
+
+    // First entry is always a system message
+    expect(result[0]).toMatchObject({
+      type: 'message',
+      actorType: 'System',
+      title: 'Starting trajectory visualization'
+    });
+
+    // Second entry is the user message
+    expect(result[1]).toMatchObject({
+      type: 'message',
+      timestamp: '2025-03-07T17:45:00.000Z',
+      content: 'Hello, I need help with my code.',
+      actorType: 'User'
+    });
+
+    // Third entry is the assistant message
+    expect(result[2]).toMatchObject({
+      type: 'message',
+      timestamp: '2025-03-07T17:45:10.000Z',
+      content: 'Let me analyze the code and identify potential issues.',
+      actorType: 'Assistant'
+    });
+  });
+
   it('should correctly process the message "Please read the README" through all steps', () => {
     // Step 1: Test the raw trajectory entry
     const trajectoryEntry = {

--- a/src/utils/__tests__/openhands-converter.test.ts
+++ b/src/utils/__tests__/openhands-converter.test.ts
@@ -311,24 +311,68 @@ describe('OpenHands Trajectory Converter', () => {
     const historyData = {
       history: [
         {
-          id: 1,
+          id: 0,
           timestamp: '2025-03-07T17:45:00.000Z',
-          type: 'message',
-          content: 'Hello, I need help with my code.',
-          actorType: 'User'
+          source: 'user',
+          message: 'Hello, I need help with my code.',
+          action: 'message',
+          args: {
+            content: 'Hello, I need help with my code.'
+          }
+        },
+        {
+          id: 1,
+          timestamp: '2025-03-07T17:45:10.000Z',
+          source: 'agent',
+          message: 'Let me check the code.',
+          action: 'read',
+          args: {
+            path: '/workspace/code.py',
+            content: 'def hello():\n    print("Hello")'
+          }
         },
         {
           id: 2,
-          timestamp: '2025-03-07T17:45:10.000Z',
-          type: 'thought',
-          content: 'Let me analyze the code and identify potential issues.',
-          actorType: 'Assistant'
+          timestamp: '2025-03-07T17:45:20.000Z',
+          source: 'agent',
+          message: 'Running tests',
+          action: 'execute_bash',
+          args: {
+            command: 'python -m pytest'
+          }
         }
       ]
     };
 
     const entries = convertOpenHandsTrajectory(historyData);
-    expect(entries).toEqual(historyData.history);
+    
+    // First entry is a message
+    expect(entries[0]).toMatchObject({
+      type: 'message',
+      timestamp: '2025-03-07T17:45:00.000Z',
+      title: 'Hello, I need help with my code.',
+      content: 'Hello, I need help with my code.',
+      actorType: 'User'
+    });
+
+    // Second entry is a search (read)
+    expect(entries[1]).toMatchObject({
+      type: 'search',
+      timestamp: '2025-03-07T17:45:10.000Z',
+      title: 'Let me check the code.',
+      content: 'def hello():\n    print("Hello")',
+      actorType: 'Assistant',
+      path: '/workspace/code.py'
+    });
+
+    // Third entry is a command
+    expect(entries[2]).toMatchObject({
+      type: 'command',
+      timestamp: '2025-03-07T17:45:20.000Z',
+      title: 'Running tests',
+      actorType: 'Assistant',
+      command: 'python -m pytest'
+    });
   });
 
   it('should handle git patch format', () => {

--- a/src/utils/__tests__/openhands-converter.test.ts
+++ b/src/utils/__tests__/openhands-converter.test.ts
@@ -307,6 +307,30 @@ describe('OpenHands Trajectory Converter', () => {
     });
   });
 
+  it('should handle history format', () => {
+    const historyData = {
+      history: [
+        {
+          id: 1,
+          timestamp: '2025-03-07T17:45:00.000Z',
+          type: 'message',
+          content: 'Hello, I need help with my code.',
+          actorType: 'User'
+        },
+        {
+          id: 2,
+          timestamp: '2025-03-07T17:45:10.000Z',
+          type: 'thought',
+          content: 'Let me analyze the code and identify potential issues.',
+          actorType: 'Assistant'
+        }
+      ]
+    };
+
+    const entries = convertOpenHandsTrajectory(historyData);
+    expect(entries).toEqual(historyData.history);
+  });
+
   it('should handle git patch format', () => {
     const gitPatchData = {
       test_result: {

--- a/src/utils/__tests__/openhands-converter.test.ts
+++ b/src/utils/__tests__/openhands-converter.test.ts
@@ -310,16 +310,34 @@ describe('OpenHands Trajectory Converter', () => {
   it('should handle git patch format', () => {
     const gitPatchData = {
       test_result: {
-        git_patch: 'diff --git a/file.txt b/file.txt\nindex 123..456 789\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-old\n+new'
+        git_patch: 'diff --git a/file1.txt b/file1.txt\nindex 123..456 789\n--- a/file1.txt\n+++ b/file1.txt\n@@ -1,1 +1,1 @@\n-old\n+new\ndiff --git a/file2.txt b/file2.txt\nindex 789..012 345\n--- a/file2.txt\n+++ b/file2.txt\n@@ -1,1 +1,1 @@\n-foo\n+bar'
       }
     };
 
     const entries = convertOpenHandsTrajectory(gitPatchData);
-    expect(entries).toHaveLength(1);
+    expect(entries).toHaveLength(3); // Git patch message + 2 file changes
+
+    // First entry is the git patch
     expect(entries[0]).toMatchObject({
       type: 'message',
       title: 'Git Patch',
       content: gitPatchData.test_result.git_patch,
+      actorType: 'System'
+    });
+
+    // Second entry is the first file change
+    expect(entries[1]).toMatchObject({
+      type: 'edit',
+      title: 'Changes in file1.txt',
+      path: 'file1.txt',
+      actorType: 'System'
+    });
+
+    // Third entry is the second file change
+    expect(entries[2]).toMatchObject({
+      type: 'edit',
+      title: 'Changes in file2.txt',
+      path: 'file2.txt',
       actorType: 'System'
     });
   });

--- a/src/utils/__tests__/openhands-converter.test.ts
+++ b/src/utils/__tests__/openhands-converter.test.ts
@@ -307,6 +307,34 @@ describe('OpenHands Trajectory Converter', () => {
     });
   });
 
+  it('should handle git patch format', () => {
+    const gitPatchData = {
+      test_result: {
+        git_patch: 'diff --git a/file.txt b/file.txt\nindex 123..456 789\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-old\n+new'
+      }
+    };
+
+    const entries = convertOpenHandsTrajectory(gitPatchData);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      type: 'message',
+      title: 'Git Patch',
+      content: gitPatchData.test_result.git_patch,
+      actorType: 'System'
+    });
+  });
+
+  it('should handle invalid formats with error', () => {
+    // Invalid format - not an array or object with entries
+    expect(() => convertOpenHandsTrajectory({} as any)).toThrow('Invalid trajectory format');
+
+    // Invalid format - entries is not an array
+    expect(() => convertOpenHandsTrajectory({ entries: 'not an array' } as any)).toThrow('Events must be an array');
+
+    // Invalid format - test_result without git_patch
+    expect(() => convertOpenHandsTrajectory({ test_result: {} } as any)).toThrow('Invalid trajectory format');
+  });
+
   it('should correctly process the message "Please read the README" through all steps', () => {
     // Step 1: Test the raw trajectory entry
     const trajectoryEntry = {

--- a/src/utils/openhands-converter.ts
+++ b/src/utils/openhands-converter.ts
@@ -27,7 +27,9 @@ function getActorType(source: string | undefined): 'User' | 'Assistant' | 'Syste
   return 'Assistant';
 }
 
-export function convertOpenHandsTrajectory(trajectory: OpenHandsEvent[]): OpenHandsTimelineEntry[] {
+export function convertOpenHandsTrajectory(trajectory: OpenHandsEvent[] | { entries: OpenHandsEvent[] }): OpenHandsTimelineEntry[] {
+  // Handle new format with entries array
+  const events = Array.isArray(trajectory) ? trajectory : trajectory.entries;
   // First entry is always a message showing the start
   const entries: OpenHandsTimelineEntry[] = [{
     type: 'message',
@@ -39,7 +41,7 @@ export function convertOpenHandsTrajectory(trajectory: OpenHandsEvent[]): OpenHa
     path: ''
   } as TimelineEntry];
 
-  for (const event of trajectory) {
+  for (const event of events) {
     // Skip environment state changes
     if (event.source === 'environment' && event.observation === 'agent_state_changed') {
       continue;

--- a/src/utils/openhands-converter.ts
+++ b/src/utils/openhands-converter.ts
@@ -35,6 +35,8 @@ export function convertOpenHandsTrajectory(trajectory: OpenHandsEvent[] | { entr
     events = trajectory;
   } else if ('entries' in trajectory) {
     events = trajectory.entries;
+  } else if ('history' in trajectory) {
+    return trajectory.history;
   } else if ('test_result' in trajectory && 'git_patch' in trajectory.test_result) {
     // Convert git patch to timeline entries
     const entries: TimelineEntry[] = [];
@@ -68,7 +70,7 @@ export function convertOpenHandsTrajectory(trajectory: OpenHandsEvent[] | { entr
 
     return entries;
   } else {
-    throw new Error('Invalid trajectory format. Expected an array of events, an object with "entries" array, or an object with "test_result.git_patch".');
+    throw new Error('Invalid trajectory format. Expected one of:\n1. Array of events with action, args, timestamp, etc.\n2. Object with "entries" array containing events\n3. Object with "history" array containing events\n4. Object with "test_result.git_patch" containing a git patch');
   }
 
   if (!Array.isArray(events)) {


### PR DESCRIPTION
This PR adds support for the new trajectory format that has a `history` array like what we get in `output.jsonl` when running swe-bench evaluation.

<img width="1466" alt="Screenshot 2025-03-10 at 10 35 55 AM" src="https://github.com/user-attachments/assets/5cd9492a-f9c3-4d53-8499-1a57229c79f3" />
