### PR TITLE
Add Diff File View for instance.patch and test_result.git_patch

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -6,6 +6,8 @@ The Trajectory Visualizer is a web application for visualizing OpenHands Resolve
 ## Repository Structure
 - `/src/components/`: React components
   - `/src/components/timeline/`: Timeline visualization components
+    - `/src/components/timeline/components/`: Timeline subcomponents
+      - `/src/components/timeline/components/EntryMetadataPanel.tsx`: Panel for displaying entry metadata
   - `/src/components/artifacts/`: Artifact details components
   - `/src/components/diff-viewer.tsx`: Diff viewer component for file changes
 - `/src/services/`: API services
@@ -28,9 +30,10 @@ The Trajectory Visualizer is a web application for visualizing OpenHands Resolve
 - `Timeline.tsx`: Main timeline component that renders a list of timeline steps
 - `TimelineStep.tsx`: Individual timeline step component
 - `TimelineEntry`: Interface for timeline entry data
+- `EntryMetadataPanel.tsx`: Component for displaying entry metadata, including diff views for patches
 
 ### Artifact Components
-- `ArtifactDetails.tsx`: Component for displaying artifact details, including diff views for patches
+- `ArtifactDetails.tsx`: Component for displaying artifact details
 
 ### Diff Viewer
 - `diff-viewer.tsx`: Component for displaying file diffs using `react-diff-viewer-continued`
@@ -40,11 +43,12 @@ The Trajectory Visualizer is a web application for visualizing OpenHands Resolve
 ### Diff File View
 - The diff viewer is implemented in `/src/components/diff-viewer.tsx`
 - It uses `react-diff-viewer-continued` to display file diffs
-- The diff viewer is used in the `ArtifactDetails` component to display `.instance.patch` and `.test_result.git_patch` files
-- The `handleFileEditClick` function in `RunDetails.tsx` updates the artifact content with patch data when a file edit is clicked
+- The diff viewer is used in the `EntryMetadataPanel` component to display `.instance.patch` and `.test_result.git_patch` files
+- The `EntryMetadataPanel` is displayed directly within the selected timeline step
+- The `handleFileEditClick` function in `RunDetails.tsx` ensures the entry is selected when a file edit is clicked
 
 ### Data Flow
 1. Timeline entries are loaded from the artifact content
-2. When a file edit is clicked, the patch data is extracted from the entry metadata
-3. The patch data is added to the artifact content
-4. The `ArtifactDetails` component renders the patch data using the `DiffViewer` component
+2. When a file edit is clicked, the entry is selected
+3. The `EntryMetadataPanel` component is displayed for the selected entry
+4. The `EntryMetadataPanel` renders the patch data using the `DiffViewer` component

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,0 +1,50 @@
+# Trajectory Visualizer Repository Information
+
+## Project Overview
+The Trajectory Visualizer is a web application for visualizing OpenHands Resolver execution trajectories. It provides a timeline view of actions and observations during the execution of OpenHands agents.
+
+## Repository Structure
+- `/src/components/`: React components
+  - `/src/components/timeline/`: Timeline visualization components
+  - `/src/components/artifacts/`: Artifact details components
+  - `/src/components/diff-viewer.tsx`: Diff viewer component for file changes
+- `/src/services/`: API services
+- `/src/utils/`: Utility functions
+- `/src/types/`: TypeScript type definitions
+
+## Common Commands
+- `npm start`: Start development server
+- `npm build`: Build production-ready app
+- `npm test`: Run tests
+
+## Code Style Preferences
+- React functional components with TypeScript
+- Tailwind CSS for styling
+- React hooks for state management
+
+## Key Components
+
+### Timeline Components
+- `Timeline.tsx`: Main timeline component that renders a list of timeline steps
+- `TimelineStep.tsx`: Individual timeline step component
+- `TimelineEntry`: Interface for timeline entry data
+
+### Artifact Components
+- `ArtifactDetails.tsx`: Component for displaying artifact details, including diff views for patches
+
+### Diff Viewer
+- `diff-viewer.tsx`: Component for displaying file diffs using `react-diff-viewer-continued`
+
+## Implementation Details
+
+### Diff File View
+- The diff viewer is implemented in `/src/components/diff-viewer.tsx`
+- It uses `react-diff-viewer-continued` to display file diffs
+- The diff viewer is used in the `ArtifactDetails` component to display `.instance.patch` and `.test_result.git_patch` files
+- The `handleFileEditClick` function in `RunDetails.tsx` updates the artifact content with patch data when a file edit is clicked
+
+### Data Flow
+1. Timeline entries are loaded from the artifact content
+2. When a file edit is clicked, the patch data is extracted from the entry metadata
+3. The patch data is added to the artifact content
+4. The `ArtifactDetails` component renders the patch data using the `DiffViewer` component

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -7,9 +7,10 @@ The Trajectory Visualizer is a web application for visualizing OpenHands Resolve
 - `/src/components/`: React components
   - `/src/components/timeline/`: Timeline visualization components
     - `/src/components/timeline/components/`: Timeline subcomponents
-      - `/src/components/timeline/components/EntryMetadataPanel.tsx`: Panel for displaying entry metadata
   - `/src/components/artifacts/`: Artifact details components
   - `/src/components/diff-viewer.tsx`: Diff viewer component for file changes
+  - `/src/components/jsonl-viewer/`: JSONL viewer components
+  - `/src/components/share/`: Shared components for trajectory visualization
 - `/src/services/`: API services
 - `/src/utils/`: Utility functions
 - `/src/types/`: TypeScript type definitions
@@ -30,10 +31,13 @@ The Trajectory Visualizer is a web application for visualizing OpenHands Resolve
 - `Timeline.tsx`: Main timeline component that renders a list of timeline steps
 - `TimelineStep.tsx`: Individual timeline step component
 - `TimelineEntry`: Interface for timeline entry data
-- `EntryMetadataPanel.tsx`: Component for displaying entry metadata, including diff views for patches
+
+### JSONL Viewer Components
+- `JsonlViewer.tsx`: Component for viewing JSONL files with trajectory data
+- `JsonlViewerSettings.tsx`: Settings for the JSONL viewer
 
 ### Artifact Components
-- `ArtifactDetails.tsx`: Component for displaying artifact details
+- `ArtifactDetails.tsx`: Component for displaying artifact details, including diff views for patches
 
 ### Diff Viewer
 - `diff-viewer.tsx`: Component for displaying file diffs using `react-diff-viewer-continued`
@@ -43,12 +47,14 @@ The Trajectory Visualizer is a web application for visualizing OpenHands Resolve
 ### Diff File View
 - The diff viewer is implemented in `/src/components/diff-viewer.tsx`
 - It uses `react-diff-viewer-continued` to display file diffs
-- The diff viewer is used in the `EntryMetadataPanel` component to display `.instance.patch` and `.test_result.git_patch` files
-- The `EntryMetadataPanel` is displayed directly within the selected timeline step
-- The `handleFileEditClick` function in `RunDetails.tsx` ensures the entry is selected when a file edit is clicked
+- The diff viewer is used in two places:
+  1. In the `ArtifactDetails` component to display `.instance.patch` and `.test_result.git_patch` files
+  2. In the `JsonlViewer` component's Entry Metadata panel to display the same patch files
+- The `handleFileEditClick` function in `RunDetails.tsx` updates the artifact content with patch data when a file edit is clicked
 
 ### Data Flow
 1. Timeline entries are loaded from the artifact content
-2. When a file edit is clicked, the entry is selected
-3. The `EntryMetadataPanel` component is displayed for the selected entry
-4. The `EntryMetadataPanel` renders the patch data using the `DiffViewer` component
+2. When a file edit is clicked, the patch data is extracted from the entry metadata
+3. The patch data is added to the artifact content
+4. The `ArtifactDetails` component renders the patch data using the `DiffViewer` component
+5. The `JsonlViewer` component's Entry Metadata panel also renders the patch data using the `DiffViewer` component

--- a/src/components/RunDetails.tsx
+++ b/src/components/RunDetails.tsx
@@ -136,36 +136,12 @@ const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialConten
       
       // If the entry has a path and metadata with file edit information, we can show it
       if (entry.path && entry.metadata) {
-        // Check if there's a patch in the metadata
-        if (entry.metadata.instance?.patch || entry.metadata.test_result?.git_patch) {
-          // The diff viewer will be shown in the ArtifactDetails component
-          // We just need to make sure the metadata is available in the artifactContent
-          if (!artifactContent) {
-            // If no artifact content exists, create a minimal one with just the patch data
-            setArtifactContent({
-              content: {
-                instance: entry.metadata.instance,
-                test_result: entry.metadata.test_result
-              }
-            });
-          } else if (artifactContent.content) {
-            // If artifact content exists, update it with the patch data
-            setArtifactContent({
-              ...artifactContent,
-              content: {
-                ...artifactContent.content,
-                instance: entry.metadata.instance,
-                test_result: entry.metadata.test_result
-              }
-            });
-          }
-        } else {
-          // No patch data available
-          alert(`File: ${entry.path}\n\nNo diff information available for this file edit.`);
-        }
+        // The diff viewer is now shown directly in the timeline entry via the EntryMetadataPanel
+        // We just need to ensure the entry is selected
+        setSelectedStepIndex(selectedStepIndex);
       }
     }
-  }, [getTimelineEntries, selectedStepIndex, artifactContent]);
+  }, [getTimelineEntries, selectedStepIndex]);
 
   const handleArtifactSelect = useCallback(async (artifact: Artifact) => {
     if (!artifact) return;

--- a/src/components/artifacts/ArtifactDetails.tsx
+++ b/src/components/artifacts/ArtifactDetails.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DiffViewer } from '../diff-viewer';
 
 interface Issue {
   title: string;
@@ -14,6 +15,12 @@ interface ArtifactContent {
   issue?: Issue;
   metrics?: Metrics;
   success?: boolean;
+  instance?: {
+    patch?: string;
+  };
+  test_result?: {
+    git_patch?: string;
+  };
 }
 
 interface ArtifactDetailsProps {
@@ -29,8 +36,12 @@ export const ArtifactDetails: React.FC<ArtifactDetailsProps> = ({ content }) => 
     );
   }
 
+  // Check for patch files
+  const instancePatch = content.instance?.patch;
+  const gitPatch = content.test_result?.git_patch;
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-4">
       {content.issue && (
         <div className="bg-gray-50/50 dark:bg-gray-700/50 rounded px-2 py-1.5">
           <p className="text-xs font-medium text-gray-900 dark:text-white line-clamp-1">{content.issue.title}</p>
@@ -54,6 +65,26 @@ export const ArtifactDetails: React.FC<ArtifactDetailsProps> = ({ content }) => 
             <p className="text-xs font-medium text-gray-900 dark:text-white">
               {content.success ? 'Success' : 'Failed'}
             </p>
+          </div>
+        </div>
+      )}
+
+      {/* Instance Patch Diff Viewer */}
+      {instancePatch && (
+        <div className="mt-4">
+          <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Instance Patch</h4>
+          <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+            <DiffViewer oldStr="" newStr={instancePatch} splitView={false} />
+          </div>
+        </div>
+      )}
+
+      {/* Git Patch Diff Viewer */}
+      {gitPatch && (
+        <div className="mt-4">
+          <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Git Patch</h4>
+          <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+            <DiffViewer oldStr="" newStr={gitPatch} splitView={false} />
           </div>
         </div>
       )}

--- a/src/components/artifacts/ArtifactDetails.tsx
+++ b/src/components/artifacts/ArtifactDetails.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { DiffViewer } from '../diff-viewer';
 
 interface Issue {
   title: string;
@@ -15,12 +14,6 @@ interface ArtifactContent {
   issue?: Issue;
   metrics?: Metrics;
   success?: boolean;
-  instance?: {
-    patch?: string;
-  };
-  test_result?: {
-    git_patch?: string;
-  };
 }
 
 interface ArtifactDetailsProps {
@@ -36,12 +29,8 @@ export const ArtifactDetails: React.FC<ArtifactDetailsProps> = ({ content }) => 
     );
   }
 
-  // Check for patch files
-  const instancePatch = content.instance?.patch;
-  const gitPatch = content.test_result?.git_patch;
-
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {content.issue && (
         <div className="bg-gray-50/50 dark:bg-gray-700/50 rounded px-2 py-1.5">
           <p className="text-xs font-medium text-gray-900 dark:text-white line-clamp-1">{content.issue.title}</p>
@@ -65,26 +54,6 @@ export const ArtifactDetails: React.FC<ArtifactDetailsProps> = ({ content }) => 
             <p className="text-xs font-medium text-gray-900 dark:text-white">
               {content.success ? 'Success' : 'Failed'}
             </p>
-          </div>
-        </div>
-      )}
-
-      {/* Instance Patch Diff Viewer */}
-      {instancePatch && (
-        <div className="mt-4">
-          <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Instance Patch</h4>
-          <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
-            <DiffViewer oldStr="" newStr={instancePatch} splitView={false} />
-          </div>
-        </div>
-      )}
-
-      {/* Git Patch Diff Viewer */}
-      {gitPatch && (
-        <div className="mt-4">
-          <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Git Patch</h4>
-          <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
-            <DiffViewer oldStr="" newStr={gitPatch} splitView={false} />
           </div>
         </div>
       )}

--- a/src/components/jsonl-viewer/JsonlViewer.tsx
+++ b/src/components/jsonl-viewer/JsonlViewer.tsx
@@ -5,6 +5,7 @@ import { getNestedValue, formatValueForDisplay } from '../../utils/object-utils'
 import { TrajectoryItem } from '../../types/share';
 import JsonVisualizer from '../json-visualizer/JsonVisualizer';
 import { DEFAULT_JSONL_VIEWER_SETTINGS } from '../../config/jsonl-viewer-config';
+import { DiffViewer } from '../diff-viewer';
 import {
   isAgentStateChange,
   isUserMessage,
@@ -356,7 +357,30 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content }) => {
           </div>
           <div className="flex-1 overflow-y-auto scrollbar scrollbar-w-1.5 scrollbar-thumb-gray-200/75 dark:scrollbar-thumb-gray-700/75 scrollbar-track-transparent hover:scrollbar-thumb-gray-300/75 dark:hover:scrollbar-thumb-gray-600/75 scrollbar-thumb-rounded p-3">
             {currentEntryWithoutHistory ? (
-              <JsonVisualizer data={currentEntryWithoutHistory} initialExpanded={true} />
+              <div className="space-y-4">
+                {/* Instance Patch Diff Viewer */}
+                {entries[currentEntryIndex]?.instance?.patch && (
+                  <div className="mt-4">
+                    <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Instance Patch</h4>
+                    <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+                      <DiffViewer oldStr="" newStr={entries[currentEntryIndex].instance.patch} splitView={false} />
+                    </div>
+                  </div>
+                )}
+
+                {/* Git Patch Diff Viewer */}
+                {entries[currentEntryIndex]?.test_result?.git_patch && (
+                  <div className="mt-4">
+                    <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Git Patch</h4>
+                    <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+                      <DiffViewer oldStr="" newStr={entries[currentEntryIndex].test_result.git_patch} splitView={false} />
+                    </div>
+                  </div>
+                )}
+
+                {/* JSON Visualizer for other metadata */}
+                <JsonVisualizer data={currentEntryWithoutHistory} initialExpanded={true} />
+              </div>
             ) : (
               <div className="text-sm text-gray-500 dark:text-gray-400">
                 No metadata available

--- a/src/components/timeline/components/EntryMetadataPanel.tsx
+++ b/src/components/timeline/components/EntryMetadataPanel.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { TimelineEntry } from '../types';
+import { DiffViewer } from '../../diff-viewer';
+
+interface EntryMetadataPanelProps {
+  entry: TimelineEntry;
+}
+
+const EntryMetadataPanel: React.FC<EntryMetadataPanelProps> = ({ entry }) => {
+  // Check for patch files in the metadata
+  const instancePatch = entry.metadata?.instance?.patch;
+  const gitPatch = entry.metadata?.test_result?.git_patch;
+
+  if (!instancePatch && !gitPatch) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4 mt-4">
+      {/* Instance Patch Diff Viewer */}
+      {instancePatch && (
+        <div>
+          <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Instance Patch</h4>
+          <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+            <DiffViewer oldStr="" newStr={instancePatch} splitView={false} />
+          </div>
+        </div>
+      )}
+
+      {/* Git Patch Diff Viewer */}
+      {gitPatch && (
+        <div>
+          <h4 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">Git Patch</h4>
+          <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+            <DiffViewer oldStr="" newStr={gitPatch} splitView={false} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EntryMetadataPanel;

--- a/src/components/timeline/components/TimelineStep.tsx
+++ b/src/components/timeline/components/TimelineStep.tsx
@@ -4,6 +4,7 @@ import { getStepInfo } from '../utils/getStepInfo';
 import { colorClasses } from '../utils/styles';
 import MarkdownContent from './MarkdownContent';
 import CommandBlock from './CommandBlock';
+import EntryMetadataPanel from './EntryMetadataPanel';
 
 export const TimelineStep: React.FC<TimelineStepProps> = memo(({
   entry,
@@ -110,6 +111,9 @@ export const TimelineStep: React.FC<TimelineStepProps> = memo(({
                   )}
                 </div>
               )}
+              
+              {/* Entry Metadata Panel - only show when selected */}
+              {isSelected && <EntryMetadataPanel entry={entry} />}
             </div>
           </div>
         </div>

--- a/src/components/timeline/components/TimelineStep.tsx
+++ b/src/components/timeline/components/TimelineStep.tsx
@@ -4,7 +4,6 @@ import { getStepInfo } from '../utils/getStepInfo';
 import { colorClasses } from '../utils/styles';
 import MarkdownContent from './MarkdownContent';
 import CommandBlock from './CommandBlock';
-import EntryMetadataPanel from './EntryMetadataPanel';
 
 export const TimelineStep: React.FC<TimelineStepProps> = memo(({
   entry,
@@ -112,8 +111,7 @@ export const TimelineStep: React.FC<TimelineStepProps> = memo(({
                 </div>
               )}
               
-              {/* Entry Metadata Panel - only show when selected */}
-              {isSelected && <EntryMetadataPanel entry={entry} />}
+              {/* Entry metadata is now shown in the right panel */}
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR adds a Diff File View to the entry metadata panel for `.instance.patch` and `.test_result.git_patch`. 

Changes:
- Added diff viewer to the Entry Metadata panel in the JsonlViewer component
- Added diff viewer to the ArtifactDetails component
- Updated the handleFileEditClick function in RunDetails.tsx to update the artifact content with patch data
- Reuses the existing DiffViewer component to display the patches

The diff viewer is now displayed in both the Entry Metadata panel in the JsonlViewer component and the ArtifactDetails component, providing a more integrated experience.