### PR TITLE
Replace All-Hands-AI references with OpenHands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A modern web application for visualizing OpenHands Resolver and their execution 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/All-Hands-AI/trajectory-visualizer.git
+   git clone https://github.com/OpenHands/trajectory-visualizer.git
    cd trajectory-visualizer
    ```
 


### PR DESCRIPTION
This PR replaces all occurrences of 'All-Hands-AI' with 'OpenHands' or 'openhands' while preserving case patterns.

## Changes made:
- `All-Hands-AI` → `OpenHands`
- `all-hands-ai` → `openhands`
- `ALL-HANDS-AI` → `OPENHANDS`
- Other case variations handled appropriately

This is part of the organization rebranding effort.

## Files changed:
- 1 files were modified

## Review notes:
- All changes are simple string replacements
- Case patterns are preserved
- No functional changes to code logic