### PR TITLE
Fix GHSA-73rr-hh4g-fpgx: Update diff to 8.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "axios": "^1.13.2",
         "browser-process-hrtime": "^1.0.0",
         "clsx": "^2.1.1",
-        "diff": "^8.0.2",
+        "diff": "8.0.3",
         "jszip": "^3.10.1",
         "path-browserify": "^1.0.1",
         "react": "^19.2.3",
@@ -2901,9 +2901,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -5622,15 +5622,6 @@
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-diff-viewer-continued/node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
   },
   "private": true,
   "type": "module",
+  "overrides": {
+    "diff": "8.0.3"
+  },
   "dependencies": {
     "axios": "^1.13.2",
     "browser-process-hrtime": "^1.0.0",
     "clsx": "^2.1.1",
-    "diff": "^8.0.2",
+    "diff": "8.0.3",
     "jszip": "^3.10.1",
     "path-browserify": "^1.0.1",
     "react": "^19.2.3",


### PR DESCRIPTION
## Security Fix

This PR fixes the security vulnerability **GHSA-73rr-hh4g-fpgx** in the `diff` package.

### Changes Made

- Added npm `overrides` configuration to force all instances of `diff` to use version 8.0.3
- Updated direct dependency from `^8.0.2` to `8.0.3`
- This fixes the vulnerability in the nested dependency from `react-diff-viewer-continued`

### Vulnerability Details

- **CVE ID**: GHSA-73rr-hh4g-fpgx
- **Package**: diff
- **Previous Version**: 5.2.0 (nested dependency)
- **Fixed Version**: 8.0.3

### Verification

```
$ npm ls diff
trajectory-visualizer@0.0.1
├── diff@8.0.3 overridden
└─┬ react-diff-viewer-continued@4.0.6
  └── diff@8.0.3 deduped
```

All instances of `diff` are now using the patched version 8.0.3.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5399adfc3c774971b1c5293ef4ee7053)