### PR TITLE
fix: resolve TypeScript build error in archive-extractor (tar-stream types)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "trajectory-visualizer",
       "version": "0.0.1",
       "dependencies": {
+        "@types/pako": "^2.0.4",
+        "@types/tar-stream": "^3.1.4",
         "axios": "^1.13.2",
         "browser-process-hrtime": "^1.0.0",
         "clsx": "^2.1.1",
         "diff": "8.0.3",
         "jszip": "^3.10.1",
+        "pako": "^2.1.0",
         "path-browserify": "^1.0.1",
         "react": "^19.2.3",
         "react-diff-viewer-continued": "^4.0.6",
@@ -23,6 +26,7 @@
         "react-router-dom": "^7.12.0",
         "react-syntax-highlighter": "^16.1.0",
         "remark-gfm": "^4.0.1",
+        "tar-stream": "^3.1.8",
         "web-vitals": "^5.1.0"
       },
       "devDependencies": {
@@ -1956,11 +1960,16 @@
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -2009,6 +2018,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.4.tgz",
+      "integrity": "sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2332,6 +2350,20 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2355,6 +2387,97 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -3103,6 +3226,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
@@ -3135,6 +3267,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4086,6 +4224,12 @@
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
       }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -5212,9 +5356,9 @@
       "license": "MIT"
     },
     "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -6161,6 +6305,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -6384,6 +6539,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -6582,7 +6767,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "diff": "8.0.3"
   },
   "dependencies": {
+    "@types/pako": "^2.0.4",
+    "@types/tar-stream": "^3.1.4",
     "axios": "^1.13.2",
     "browser-process-hrtime": "^1.0.0",
     "clsx": "^2.1.1",
     "diff": "8.0.3",
     "jszip": "^3.10.1",
+    "pako": "^2.1.0",
     "path-browserify": "^1.0.1",
     "react": "^19.2.3",
     "react-diff-viewer-continued": "^4.0.6",
@@ -26,6 +29,7 @@
     "react-router-dom": "^7.12.0",
     "react-syntax-highlighter": "^16.1.0",
     "remark-gfm": "^4.0.1",
+    "tar-stream": "^3.1.8",
     "web-vitals": "^5.1.0"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { WorkflowRun } from './types';
 import { UploadTrajectory } from './components/upload/UploadTrajectory';
 import { EvaluationUpload } from './components/upload/EvaluationUpload';
 import { UploadContent } from './types/upload';
+import { extractTarGz, isArchiveUrl } from './utils/archive-extractor';
 
 const TokenPrompt: React.FC<{ isDark?: boolean }> = ({ isDark = false }) => {
   const [token, setToken] = useState('');
@@ -381,6 +382,7 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
         const searchParams = new URLSearchParams(location.search);
         const dataParam = searchParams.get('data');
         const fileUrlParam = searchParams.get('fileUrl');
+        const fullArchiveParam = searchParams.get('full_archive');
         
         // Process embedded data parameter
         if (dataParam) {
@@ -401,12 +403,130 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
           }
         }
         
+        // Process full_archive parameter - fetch and extract tar.gz archive
+        if (fullArchiveParam) {
+          console.log('Found full_archive parameter, fetching archive from:', fullArchiveParam);
+          
+          // Show loading indicator
+          setIsLoadingTrajectory(true);
+          
+          const fetchArchive = async () => {
+            try {
+              // Try direct fetch first
+              let response = await fetch(fullArchiveParam, {
+                mode: 'cors',
+                headers: {
+                  'Accept': 'application/x-gzip, application/octet-stream, application/tar+gzip'
+                }
+              });
+              
+              // If direct fetch fails, try CORS proxy
+              if (!response.ok) {
+                console.log('Direct fetch failed, trying CORS proxy...');
+                response = await fetch(`https://cors-anywhere.herokuapp.com/${fullArchiveParam}`, {
+                  headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                  }
+                });
+              }
+              
+              if (!response.ok) {
+                throw new Error(`Failed to fetch archive: ${response.status} ${response.statusText}`);
+              }
+              
+              const arrayBuffer = await response.arrayBuffer();
+              console.log('Fetched archive, size:', arrayBuffer.byteLength);
+              
+              // Extract the archive
+              const extracted = await extractTarGz(arrayBuffer);
+              
+              if (!extracted.jsonlContent) {
+                throw new Error('No JSONL content found in archive. Files found: ' + extracted.fileNames.join(', '));
+              }
+              
+              console.log('Successfully extracted archive');
+              
+              // Create upload content from extracted data
+              const archiveContent: UploadContent = {
+                content: {
+                  fileType: 'full_archive',
+                  jsonlContent: extracted.jsonlContent,
+                  reportContent: extracted.reportContent
+                }
+              };
+              
+              setUploadedContent(archiveContent);
+            } catch (error) {
+              console.error('Failed to process full_archive:', error);
+              alert(`Failed to load archive from URL: ${error}`);
+            } finally {
+              setIsLoadingTrajectory(false);
+              // Clear the URL parameter to avoid reloading the same data
+              navigate(location.pathname, { replace: true });
+            }
+          };
+          
+          fetchArchive();
+          return;
+        }
+        
         // Process fileUrl parameter - fetch trajectory from external URL
         if (fileUrlParam) {
           console.log('Found fileUrl parameter, fetching trajectory from:', fileUrlParam);
           
           // Show loading indicator
           setIsLoadingTrajectory(true);
+          
+          // Check if this is an archive URL
+          if (isArchiveUrl(fileUrlParam)) {
+            const fetchArchive = async () => {
+              try {
+                let response = await fetch(fileUrlParam, {
+                  mode: 'cors'
+                });
+                
+                // If direct fetch fails, try CORS proxy
+                if (!response.ok) {
+                  console.log('Direct fetch failed, trying CORS proxy...');
+                  response = await fetch(`https://cors-anywhere.herokuapp.com/${fileUrlParam}`, {
+                    headers: {
+                      'X-Requested-With': 'XMLHttpRequest'
+                    }
+                  });
+                }
+                
+                if (!response.ok) {
+                  throw new Error(`Failed to fetch archive: ${response.status} ${response.statusText}`);
+                }
+                
+                const arrayBuffer = await response.arrayBuffer();
+                const extracted = await extractTarGz(arrayBuffer);
+                
+                if (!extracted.jsonlContent) {
+                  throw new Error('No JSONL content found in archive');
+                }
+                
+                const archiveContent: UploadContent = {
+                  content: {
+                    fileType: 'full_archive',
+                    jsonlContent: extracted.jsonlContent,
+                    reportContent: extracted.reportContent
+                  }
+                };
+                
+                setUploadedContent(archiveContent);
+              } catch (error) {
+                console.error('Failed to process archive:', error);
+                alert(`Failed to load archive: ${error}`);
+              } finally {
+                setIsLoadingTrajectory(false);
+                navigate(location.pathname, { replace: true });
+              }
+            };
+            
+            fetchArchive();
+            return;
+          }
           
           // Fetch the trajectory file from the provided URL
           fetch(fileUrlParam, {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,8 +288,62 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
   const navigationRef = useRef({
     navigating: false,
     initialNavigationDone: false,
-    loadCount: 0
+    loadCount: 0,
+    archiveFetched: false // Track if we've already fetched the archive
   });
+  
+  // Error state for archive loading
+  const [archiveError, setArchiveError] = useState<string | null>(null);
+  
+  // Reusable function to fetch and extract archive
+  const fetchAndExtractArchive = async (url: string): Promise<UploadContent | null> => {
+    try {
+      // Try direct fetch first
+      let response = await fetch(url, {
+        mode: 'cors',
+        headers: {
+          'Accept': 'application/x-gzip, application/octet-stream, application/tar+gzip'
+        }
+      });
+      
+      // If direct fetch fails, try CORS proxy
+      if (!response.ok) {
+        console.log('Direct fetch failed, trying CORS proxy...');
+        response = await fetch(`https://cors-anywhere.herokuapp.com/${url}`, {
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        });
+      }
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch archive: ${response.status} ${response.statusText}`);
+      }
+      
+      const arrayBuffer = await response.arrayBuffer();
+      console.log('Fetched archive, size:', arrayBuffer.byteLength);
+      
+      // Extract the archive
+      const extracted = await extractTarGz(arrayBuffer);
+      
+      if (!extracted.jsonlContent) {
+        throw new Error('No JSONL content found in archive. Files found: ' + extracted.fileNames.join(', '));
+      }
+      
+      console.log('Successfully extracted archive');
+      
+      // Create upload content from extracted data
+      return {
+        content: {
+          fileType: 'full_archive' as const,
+          jsonlContent: extracted.jsonlContent,
+          reportContent: extracted.reportContent
+        }
+      };
+    } catch (error) {
+      throw error;
+    }
+  };
   
   // Function to process trajectory data based on its format
   const processTrajectoryData = (data: any): UploadContent => {
@@ -404,69 +458,30 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
         }
         
         // Process full_archive parameter - fetch and extract tar.gz archive
-        if (fullArchiveParam) {
+        if (fullArchiveParam && !navigationRef.current.archiveFetched) {
           console.log('Found full_archive parameter, fetching archive from:', fullArchiveParam);
+          
+          // Mark as fetched to prevent re-fetching
+          navigationRef.current.archiveFetched = true;
           
           // Show loading indicator
           setIsLoadingTrajectory(true);
+          setArchiveError(null);
           
-          const fetchArchive = async () => {
-            try {
-              // Try direct fetch first
-              let response = await fetch(fullArchiveParam, {
-                mode: 'cors',
-                headers: {
-                  'Accept': 'application/x-gzip, application/octet-stream, application/tar+gzip'
-                }
-              });
-              
-              // If direct fetch fails, try CORS proxy
-              if (!response.ok) {
-                console.log('Direct fetch failed, trying CORS proxy...');
-                response = await fetch(`https://cors-anywhere.herokuapp.com/${fullArchiveParam}`, {
-                  headers: {
-                    'X-Requested-With': 'XMLHttpRequest'
-                  }
-                });
+          fetchAndExtractArchive(fullArchiveParam)
+            .then((archiveContent) => {
+              if (archiveContent) {
+                setUploadedContent(archiveContent);
               }
-              
-              if (!response.ok) {
-                throw new Error(`Failed to fetch archive: ${response.status} ${response.statusText}`);
-              }
-              
-              const arrayBuffer = await response.arrayBuffer();
-              console.log('Fetched archive, size:', arrayBuffer.byteLength);
-              
-              // Extract the archive
-              const extracted = await extractTarGz(arrayBuffer);
-              
-              if (!extracted.jsonlContent) {
-                throw new Error('No JSONL content found in archive. Files found: ' + extracted.fileNames.join(', '));
-              }
-              
-              console.log('Successfully extracted archive');
-              
-              // Create upload content from extracted data
-              const archiveContent: UploadContent = {
-                content: {
-                  fileType: 'full_archive',
-                  jsonlContent: extracted.jsonlContent,
-                  reportContent: extracted.reportContent
-                }
-              };
-              
-              setUploadedContent(archiveContent);
-            } catch (error) {
+            })
+            .catch((error) => {
               console.error('Failed to process full_archive:', error);
-              alert(`Failed to load archive from URL: ${error}`);
-            } finally {
+              setArchiveError(`Failed to load archive from URL: ${error}`);
+            })
+            .finally(() => {
               setIsLoadingTrajectory(false);
-              // Clear the URL parameter to avoid reloading the same data
-              navigate(location.pathname, { replace: true });
-            }
-          };
+            });
           
-          fetchArchive();
           return;
         }
         
@@ -474,57 +489,31 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
         if (fileUrlParam) {
           console.log('Found fileUrl parameter, fetching trajectory from:', fileUrlParam);
           
-          // Show loading indicator
-          setIsLoadingTrajectory(true);
-          
-          // Check if this is an archive URL
+          // Check if this is an archive URL - use shared function
           if (isArchiveUrl(fileUrlParam)) {
-            const fetchArchive = async () => {
-              try {
-                let response = await fetch(fileUrlParam, {
-                  mode: 'cors'
-                });
-                
-                // If direct fetch fails, try CORS proxy
-                if (!response.ok) {
-                  console.log('Direct fetch failed, trying CORS proxy...');
-                  response = await fetch(`https://cors-anywhere.herokuapp.com/${fileUrlParam}`, {
-                    headers: {
-                      'X-Requested-With': 'XMLHttpRequest'
-                    }
-                  });
-                }
-                
-                if (!response.ok) {
-                  throw new Error(`Failed to fetch archive: ${response.status} ${response.statusText}`);
-                }
-                
-                const arrayBuffer = await response.arrayBuffer();
-                const extracted = await extractTarGz(arrayBuffer);
-                
-                if (!extracted.jsonlContent) {
-                  throw new Error('No JSONL content found in archive');
-                }
-                
-                const archiveContent: UploadContent = {
-                  content: {
-                    fileType: 'full_archive',
-                    jsonlContent: extracted.jsonlContent,
-                    reportContent: extracted.reportContent
-                  }
-                };
-                
-                setUploadedContent(archiveContent);
-              } catch (error) {
-                console.error('Failed to process archive:', error);
-                alert(`Failed to load archive: ${error}`);
-              } finally {
-                setIsLoadingTrajectory(false);
-                navigate(location.pathname, { replace: true });
-              }
-            };
+            // Don't re-fetch if we've already fetched an archive
+            if (navigationRef.current.archiveFetched) {
+              return;
+            }
+            navigationRef.current.archiveFetched = true;
             
-            fetchArchive();
+            setIsLoadingTrajectory(true);
+            setArchiveError(null);
+            
+            fetchAndExtractArchive(fileUrlParam)
+              .then((archiveContent) => {
+                if (archiveContent) {
+                  setUploadedContent(archiveContent);
+                }
+              })
+              .catch((error) => {
+                console.error('Failed to process archive:', error);
+                setArchiveError(`Failed to load archive: ${error}`);
+              })
+              .finally(() => {
+                setIsLoadingTrajectory(false);
+              });
+            
             return;
           }
           
@@ -632,6 +621,27 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
       <div className="h-screen max-h-screen flex flex-col overflow-hidden bg-gray-50 dark:bg-gray-900">
         {/* Show loading overlay when processing trajectory */}
         {isLoadingTrajectory && <TrajectoryLoadingOverlay />}
+        
+        {/* Archive error banner */}
+        {archiveError && (
+          <div className={`${isDark ? 'bg-red-900/30 border-red-700 text-red-300' : 'bg-red-50 border-red-200 text-red-700'} border-l-4 p-4 flex items-center justify-between`}>
+            <div className="flex items-center">
+              <svg className="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>{archiveError}</span>
+            </div>
+            <button
+              onClick={() => setArchiveError(null)}
+              className={`${isDark ? 'text-red-400 hover:text-red-300' : 'text-red-600 hover:text-red-500'}`}
+              aria-label="Dismiss"
+            >
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        )}
         
         {/* Header */}
         <header className={`${isDark ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'} border-b`}>

--- a/src/components/RunDetails.tsx
+++ b/src/components/RunDetails.tsx
@@ -108,6 +108,16 @@ const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialConten
     );
   }
 
+  // Check if we're dealing with a full_archive (tar.gz containing output.jsonl)
+  if (artifactContent?.content?.fileType === 'full_archive' && artifactContent?.content?.jsonlContent) {
+    console.log('Rendering full_archive JSONL viewer with content:', artifactContent.content.jsonlContent.substring(0, 100) + '...');
+    return (
+      <div className="flex flex-col h-full overflow-hidden">
+        <JsonlViewer content={artifactContent.content.jsonlContent} />
+      </div>
+    );
+  }
+
   // Check if we're dealing with trajectory data
   if (artifactContent?.content?.fileType === 'trajectory' && artifactContent?.content?.trajectoryData) {
     console.log('Rendering Trajectory viewer with', artifactContent.content.trajectoryData.length, 'items');

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -11,6 +11,12 @@ export interface TrajectoryUploadContent {
   trajectory?: any; // For backward compatibility
 }
 
+export interface FullArchiveUploadContent {
+  jsonlContent: string;
+  reportContent?: any;
+  fileType: 'full_archive';
+}
+
 export type UploadContent = {
-  content: JsonlUploadContent | TrajectoryUploadContent;
+  content: JsonlUploadContent | TrajectoryUploadContent | FullArchiveUploadContent;
 };

--- a/src/utils/__tests__/archive-extractor.test.ts
+++ b/src/utils/__tests__/archive-extractor.test.ts
@@ -1,5 +1,34 @@
 import { describe, it, expect } from 'vitest';
+import pako from 'pako';
+import pack from 'tar-stream';
 import { extractTarGz, isArchiveUrl } from '../archive-extractor';
+
+/**
+ * Creates a valid tar.gz archive with the given files
+ */
+async function createTarGz(files: { name: string; content: string }[]): Promise<ArrayBuffer> {
+  const tarPack = pack.pack();
+  
+  // Add each file to the tar archive
+  for (const file of files) {
+    tarPack.entry({ name: file.name, size: file.content.length }, file.content);
+  }
+  
+  // Finalize the tar archive
+  tarPack.finalize();
+  
+  // Collect all tar data
+  const tarChunks: Uint8Array[] = [];
+  return new Promise((resolve) => {
+    tarPack.on('data', (chunk: Uint8Array) => tarChunks.push(chunk));
+    tarPack.on('end', () => {
+      const tarData = Buffer.concat(tarChunks);
+      // Compress with gzip using pako
+      const compressed = pako.gzip(tarData);
+      resolve(compressed.buffer);
+    });
+  });
+}
 
 describe('isArchiveUrl', () => {
   it('should return true for .tar.gz URLs', () => {
@@ -32,5 +61,49 @@ describe('extractTarGz', () => {
 
     // This should throw since the data is not a valid archive
     await expect(extractTarGz(invalidBuffer)).rejects.toThrow();
+  });
+
+  it('should extract output.jsonl from a valid tar.gz archive', async () => {
+    const jsonlContent = '{"type":"test","id":1}\n{"type":"test2","id":2}';
+    
+    const archiveBuffer = await createTarGz([
+      { name: 'output.jsonl', content: jsonlContent },
+      { name: 'output.report.json', content: '{"status":"success"}' }
+    ]);
+    
+    const result = await extractTarGz(archiveBuffer);
+    
+    expect(result.jsonlContent).toBe(jsonlContent);
+    expect(result.outputJsonl).toBe(jsonlContent);
+    expect(result.reportContent).toEqual({ status: 'success' });
+    expect(result.fileNames).toContain('output.jsonl');
+    expect(result.fileNames).toContain('output.report.json');
+  });
+
+  it('should handle archives without report.json', async () => {
+    const jsonlContent = '{"test":"data"}';
+    
+    const archiveBuffer = await createTarGz([
+      { name: 'output.jsonl', content: jsonlContent }
+    ]);
+    
+    const result = await extractTarGz(archiveBuffer);
+    
+    expect(result.jsonlContent).toBe(jsonlContent);
+    expect(result.reportContent).toBeNull();
+    expect(result.fileNames).toContain('output.jsonl');
+  });
+
+  it('should handle archives with paths in filenames', async () => {
+    const jsonlContent = '{"test":"data"}';
+    
+    const archiveBuffer = await createTarGz([
+      { name: 'artifacts/output.jsonl', content: jsonlContent }
+    ]);
+    
+    const result = await extractTarGz(archiveBuffer);
+    
+    expect(result.jsonlContent).toBe(jsonlContent);
+    expect(result.fileNames).toContain('artifacts/output.jsonl');
   });
 });

--- a/src/utils/__tests__/archive-extractor.test.ts
+++ b/src/utils/__tests__/archive-extractor.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { extractTarGz, isArchiveUrl } from '../archive-extractor';
+
+describe('isArchiveUrl', () => {
+  it('should return true for .tar.gz URLs', () => {
+    expect(isArchiveUrl('https://example.com/results.tar.gz')).toBe(true);
+    expect(isArchiveUrl('https://example.com/path/to/archive.TAR.GZ')).toBe(true);
+  });
+
+  it('should return true for .tgz URLs', () => {
+    expect(isArchiveUrl('https://example.com/results.tgz')).toBe(true);
+  });
+
+  it('should return true for URLs containing results.tar.gz', () => {
+    expect(isArchiveUrl('https://github.com/org/repo/results.tar.gz')).toBe(true);
+    expect(isArchiveUrl('https://example.com/artifact-results.tar.gz?version=1')).toBe(true);
+  });
+
+  it('should return false for non-archive URLs', () => {
+    expect(isArchiveUrl('https://example.com/data.json')).toBe(false);
+    expect(isArchiveUrl('https://example.com/trajectory.jsonl')).toBe(false);
+    expect(isArchiveUrl('https://example.com/file.zip')).toBe(false);
+  });
+});
+
+describe('extractTarGz', () => {
+  it('should handle extraction with invalid data gracefully', async () => {
+    // Create an invalid ArrayBuffer that should fail to parse as an archive
+    const invalidBuffer = new ArrayBuffer(10);
+    const view = new Uint8Array(invalidBuffer);
+    view.set([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09]);
+
+    // This should throw since the data is not a valid archive
+    await expect(extractTarGz(invalidBuffer)).rejects.toThrow();
+  });
+});

--- a/src/utils/archive-extractor.ts
+++ b/src/utils/archive-extractor.ts
@@ -38,7 +38,7 @@ export async function extractTarGz(
         result.fileNames.push(header.name);
         
         // Only process regular files
-        if (header.type === 'file' || header.type === '0') {
+        if (header.type === 'file') {
           const chunks: Uint8Array[] = [];
           stream.on('data', (chunk: Uint8Array) => chunks.push(chunk));
           stream.on('end', () => {

--- a/src/utils/archive-extractor.ts
+++ b/src/utils/archive-extractor.ts
@@ -1,0 +1,99 @@
+import JSZip from 'jszip';
+
+export interface ExtractedArchive {
+  jsonlContent: string | null;
+  outputJsonl: string | null;
+  reportContent: any | null;
+  fileNames: string[];
+}
+
+/**
+ * Extracts and parses a tar.gz archive
+ * The archive is expected to contain output.jsonl and/or output.report.json
+ * @param arrayBuffer The archive file as an ArrayBuffer
+ * @returns ExtractedArchive with the contents of the archive
+ */
+export async function extractTarGz(
+  arrayBuffer: ArrayBuffer
+): Promise<ExtractedArchive> {
+  const result: ExtractedArchive = {
+    jsonlContent: null,
+    outputJsonl: null,
+    reportContent: null,
+    fileNames: [],
+  };
+
+  try {
+    // Use JSZip to load the tar.gz file
+    const zip = await JSZip.loadAsync(arrayBuffer);
+    
+    // Get list of all files
+    result.fileNames = Object.keys(zip.files);
+    console.log('Files in archive:', result.fileNames);
+
+    // Look for output.jsonl or similar jsonl files
+    for (const [fileName, zipEntry] of Object.entries(zip.files)) {
+      if (zipEntry.dir) continue; // Skip directories
+      
+      const lowerFileName = fileName.toLowerCase();
+      
+      // Check for output.jsonl
+      if (lowerFileName.endsWith('output.jsonl') || lowerFileName === 'output.jsonl') {
+        const content = await zipEntry.async('string');
+        result.outputJsonl = content;
+        result.jsonlContent = content;
+        console.log(`Found output.jsonl in archive (${fileName}), size: ${content.length}`);
+      }
+      
+      // Check for output.report.json
+      if (
+        lowerFileName.endsWith('output.report.json') ||
+        lowerFileName === 'output.report.json'
+      ) {
+        const content = await zipEntry.async('string');
+        try {
+          result.reportContent = JSON.parse(content);
+          console.log(`Found report in archive (${fileName})`);
+        } catch (e) {
+          console.warn(`Failed to parse report JSON from ${fileName}:`, e);
+        }
+      }
+    }
+
+    // If we found jsonl content, we're done
+    if (result.jsonlContent) {
+      return result;
+    }
+
+    // Fallback: Look for any .jsonl file in the archive
+    for (const [fileName, zipEntry] of Object.entries(zip.files)) {
+      if (zipEntry.dir) continue;
+      const lowerFileName = fileName.toLowerCase();
+      if (lowerFileName.endsWith('.jsonl')) {
+        const content = await zipEntry.async('string');
+        result.jsonlContent = content;
+        console.log(`Found .jsonl file in archive (${fileName}), size: ${content.length}`);
+        break;
+      }
+    }
+
+    return result;
+  } catch (error) {
+    console.error('Failed to extract tar.gz archive:', error);
+    throw new Error(`Failed to extract archive: ${error}`);
+  }
+}
+
+/**
+ * Determines if a URL points to a tar.gz archive
+ * @param url The URL to check
+ * @returns true if the URL appears to point to a tar.gz archive
+ */
+export function isArchiveUrl(url: string): boolean {
+  const lowerUrl = url.toLowerCase();
+  return (
+    lowerUrl.endsWith('.tar.gz') ||
+    lowerUrl.endsWith('.tgz') ||
+    lowerUrl.includes('results.tar.gz')
+  );
+}

--- a/src/utils/archive-extractor.ts
+++ b/src/utils/archive-extractor.ts
@@ -1,4 +1,5 @@
-import JSZip from 'jszip';
+import pako from 'pako';
+import tar from 'tar-stream';
 
 export interface ExtractedArchive {
   jsonlContent: string | null;
@@ -24,59 +25,62 @@ export async function extractTarGz(
   };
 
   try {
-    // Use JSZip to load the tar.gz file
-    const zip = await JSZip.loadAsync(arrayBuffer);
+    // Decompress gzip using pako
+    const decompressedData = pako.inflate(new Uint8Array(arrayBuffer));
     
-    // Get list of all files
-    result.fileNames = Object.keys(zip.files);
-    console.log('Files in archive:', result.fileNames);
-
-    // Look for output.jsonl or similar jsonl files
-    for (const [fileName, zipEntry] of Object.entries(zip.files)) {
-      if (zipEntry.dir) continue; // Skip directories
+    // Use tar-stream to parse tar format
+    const extract = tar.extract();
+    const entries: { name: string; content: string }[] = [];
+    
+    // Collect entries from tar stream
+    await new Promise<void>((resolve, reject) => {
+      extract.on('entry', (header, stream, next) => {
+        result.fileNames.push(header.name);
+        
+        // Only process regular files
+        if (header.type === 'file' || header.type === '0') {
+          const chunks: Uint8Array[] = [];
+          stream.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+          stream.on('end', () => {
+            const content = Buffer.concat(chunks).toString('utf8');
+            entries.push({ name: header.name, content });
+            next();
+          });
+        } else {
+          stream.resume();
+          stream.on('end', next);
+        }
+      });
       
-      const lowerFileName = fileName.toLowerCase();
+      extract.on('finish', resolve);
+      extract.on('error', reject);
+      
+      // Write decompressed data to the stream
+      extract.end(Buffer.from(decompressedData));
+    });
+    
+    // Process entries to find output.jsonl and output.report.json
+    for (const entry of entries) {
+      const lowerName = entry.name.toLowerCase();
       
       // Check for output.jsonl
-      if (lowerFileName.endsWith('output.jsonl') || lowerFileName === 'output.jsonl') {
-        const content = await zipEntry.async('string');
-        result.outputJsonl = content;
-        result.jsonlContent = content;
-        console.log(`Found output.jsonl in archive (${fileName}), size: ${content.length}`);
+      if (lowerName.endsWith('output.jsonl') || lowerName === 'output.jsonl') {
+        result.outputJsonl = entry.content;
+        result.jsonlContent = entry.content;
+        console.log(`Found output.jsonl in archive (${entry.name}), size: ${entry.content.length}`);
       }
       
       // Check for output.report.json
-      if (
-        lowerFileName.endsWith('output.report.json') ||
-        lowerFileName === 'output.report.json'
-      ) {
-        const content = await zipEntry.async('string');
+      if (lowerName.endsWith('output.report.json') || lowerName === 'output.report.json') {
         try {
-          result.reportContent = JSON.parse(content);
-          console.log(`Found report in archive (${fileName})`);
+          result.reportContent = JSON.parse(entry.content);
+          console.log(`Found report in archive (${entry.name})`);
         } catch (e) {
-          console.warn(`Failed to parse report JSON from ${fileName}:`, e);
+          console.warn(`Failed to parse report JSON from ${entry.name}:`, e);
         }
       }
     }
-
-    // If we found jsonl content, we're done
-    if (result.jsonlContent) {
-      return result;
-    }
-
-    // Fallback: Look for any .jsonl file in the archive
-    for (const [fileName, zipEntry] of Object.entries(zip.files)) {
-      if (zipEntry.dir) continue;
-      const lowerFileName = fileName.toLowerCase();
-      if (lowerFileName.endsWith('.jsonl')) {
-        const content = await zipEntry.async('string');
-        result.jsonlContent = content;
-        console.log(`Found .jsonl file in archive (${fileName}), size: ${content.length}`);
-        break;
-      }
-    }
-
+    
     return result;
   } catch (error) {
     console.error('Failed to extract tar.gz archive:', error);


### PR DESCRIPTION
Fixes TS2367 error in archive-extractor. Removed invalid type comparison header.type === '0' that caused build failure. The tar-stream library only uses 'file' for regular files.