### PR TITLE
feat: Add inUrl parameter support for loading results.tar.gz from URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -471,18 +471,40 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
         
         // Process inUrl parameter - fetch and extract tar.gz files from URL
         if (inUrlParam) {
+          // Validate URL format for security - must be from allowed domain and be a results.tar.gz file
+          const ALLOWED_PREFIX = 'https://results.eval.all-hands.dev/';
+          const REQUIRED_SUFFIX = 'results.tar.gz';
+          
+          if (!inUrlParam.startsWith(ALLOWED_PREFIX) || !inUrlParam.endsWith(REQUIRED_SUFFIX)) {
+            console.error('Invalid inUrl: URL must start with', ALLOWED_PREFIX, 'and end with', REQUIRED_SUFFIX);
+            alert(`Invalid URL format. URL must start with "${ALLOWED_PREFIX}" and end with "${REQUIRED_SUFFIX}"`);
+            navigate(location.pathname, { replace: true });
+            return;
+          }
+          
           console.log('Found inUrl parameter, fetching tar.gz from:', inUrlParam);
           setIsLoadingTrajectory(true);
           
+          // Add timeout for fetch
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), 60000); // 60 second timeout
+          
           fetch(inUrlParam, {
             mode: 'cors',
+            signal: controller.signal,
             headers: {
               'Accept': 'application/gzip, application/x-tar, */*'
             }
           })
             .then(response => {
+              clearTimeout(timeoutId);
               if (!response.ok) {
                 throw new Error(`Failed to fetch tar.gz: ${response.status} ${response.statusText}`);
+              }
+              // Check content-length if available
+              const contentLength = response.headers.get('content-length');
+              if (contentLength && parseInt(contentLength) > 500_000_000) {
+                throw new Error('File too large (max 500MB)');
               }
               return response.arrayBuffer();
             })
@@ -493,7 +515,8 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
               let decompressed: Uint8Array;
               try {
                 decompressed = pako.ungzip(gzippedData);
-              } catch {
+              } catch (ungzipError) {
+                console.warn('ungzip failed, trying inflate:', ungzipError);
                 decompressed = pako.inflate(gzippedData);
               }
               
@@ -513,8 +536,13 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
               });
             })
             .catch(error => {
+              clearTimeout(timeoutId);
               console.error('Error fetching tar.gz from URL:', error);
-              alert(`Failed to load tar.gz from URL: ${error.message}`);
+              if (error.name === 'AbortError') {
+                alert('Request timed out. Please try again.');
+              } else {
+                alert(`Failed to load tar.gz from URL: ${error.message}`);
+              }
             })
             .finally(() => {
               setIsLoadingTrajectory(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { WorkflowRun } from './types';
 import { UploadTrajectory } from './components/upload/UploadTrajectory';
 import { EvaluationUpload } from './components/upload/EvaluationUpload';
 import { UploadContent } from './types/upload';
+import pako from 'pako';
+import { extractFromTar } from './lib/tarExtractor';
 
 const TokenPrompt: React.FC<{ isDark?: boolean }> = ({ isDark = false }) => {
   const [token, setToken] = useState('');
@@ -381,6 +383,7 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
         const searchParams = new URLSearchParams(location.search);
         const dataParam = searchParams.get('data');
         const fileUrlParam = searchParams.get('fileUrl');
+        const inUrlParam = searchParams.get('inUrl');
         
         // Process embedded data parameter
         if (dataParam) {
@@ -456,6 +459,62 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
                   alert(`Failed to load trajectory from URL: ${error.message}\nProxy attempt also failed: ${proxyError.message}`);
                   throw proxyError; // Re-throw to trigger the finally block
                 });
+            })
+            .finally(() => {
+              setIsLoadingTrajectory(false);
+              // Clear the URL parameter to avoid reloading the same data
+              navigate(location.pathname, { replace: true });
+            });
+          
+          return;
+        }
+        
+        // Process inUrl parameter - fetch and extract tar.gz files from URL
+        if (inUrlParam) {
+          console.log('Found inUrl parameter, fetching tar.gz from:', inUrlParam);
+          setIsLoadingTrajectory(true);
+          
+          fetch(inUrlParam, {
+            mode: 'cors',
+            headers: {
+              'Accept': 'application/gzip, application/x-tar, */*'
+            }
+          })
+            .then(response => {
+              if (!response.ok) {
+                throw new Error(`Failed to fetch tar.gz: ${response.status} ${response.statusText}`);
+              }
+              return response.arrayBuffer();
+            })
+            .then(buffer => {
+              console.log('Successfully fetched tar.gz, decompressing...');
+              const gzippedData = new Uint8Array(buffer);
+              
+              let decompressed: Uint8Array;
+              try {
+                decompressed = pako.ungzip(gzippedData);
+              } catch {
+                decompressed = pako.inflate(gzippedData);
+              }
+              
+              console.log('Extracting from tar...');
+              const { jsonlContent, reportContent } = extractFromTar(decompressed);
+              
+              if (!jsonlContent) {
+                throw new Error('No JSONL content found in archive');
+              }
+              
+              setUploadedContent({
+                content: {
+                  fileType: 'full_archive' as const,
+                  jsonlContent,
+                  reportContent
+                }
+              });
+            })
+            .catch(error => {
+              console.error('Error fetching tar.gz from URL:', error);
+              alert(`Failed to load tar.gz from URL: ${error.message}`);
             })
             .finally(() => {
               setIsLoadingTrajectory(false);

--- a/src/test/InUrlParameter.test.tsx
+++ b/src/test/InUrlParameter.test.tsx
@@ -123,11 +123,12 @@ describe('inUrl Parameter', () => {
     // Mock fetch to return the tar.gz
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
+      headers: new Map([['content-length', '1000']]),
       arrayBuffer: () => Promise.resolve(tarGzData.buffer)
     });
     global.fetch = fetchMock as typeof fetch;
 
-    // Render with inUrl parameter
+    // Render with inUrl parameter - must use allowed domain and suffix
     const testUrl = 'https://results.eval.all-hands.dev/test/results.tar.gz';
     render(
       <MemoryRouter initialEntries={[`/?inUrl=${encodeURIComponent(testUrl)}`]}>
@@ -135,7 +136,7 @@ describe('inUrl Parameter', () => {
       </MemoryRouter>
     );
 
-    // Wait for fetch to be called
+    // Wait for fetch to be called with correct URL and options
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         testUrl,
@@ -148,12 +149,70 @@ describe('inUrl Parameter', () => {
       );
     });
 
-    // Wait for loading to complete and content to be processed
+    // Verify fetch was called exactly once (for the tar.gz)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject URLs not from allowed domain', async () => {
+    // Mock alert
+    const alertMock = vi.fn();
+    window.alert = alertMock;
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock fetch (should not be called)
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    // Render with inUrl parameter from non-allowed domain
+    const testUrl = 'https://evil.example.com/malicious/results.tar.gz';
+    render(
+      <MemoryRouter initialEntries={[`/?inUrl=${encodeURIComponent(testUrl)}`]}>
+        <App router={false} />
+      </MemoryRouter>
+    );
+
+    // Wait for validation error
     await waitFor(() => {
-      // After loading, the URL should no longer have the inUrl parameter
-      // (it gets cleared after loading)
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-    }, { timeout: 5000 });
+      expect(alertMock).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid URL format')
+      );
+    });
+
+    // Fetch should NOT be called for invalid URLs
+    expect(fetchMock).not.toHaveBeenCalled();
+    
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should reject URLs without required suffix', async () => {
+    // Mock alert
+    const alertMock = vi.fn();
+    window.alert = alertMock;
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock fetch (should not be called)
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    // Render with inUrl parameter without results.tar.gz suffix
+    const testUrl = 'https://results.eval.all-hands.dev/test/other-file.json';
+    render(
+      <MemoryRouter initialEntries={[`/?inUrl=${encodeURIComponent(testUrl)}`]}>
+        <App router={false} />
+      </MemoryRouter>
+    );
+
+    // Wait for validation error
+    await waitFor(() => {
+      expect(alertMock).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid URL format')
+      );
+    });
+
+    // Fetch should NOT be called for invalid URLs
+    expect(fetchMock).not.toHaveBeenCalled();
+    
+    consoleErrorSpy.mockRestore();
   });
 
   it('should handle fetch errors gracefully', async () => {
@@ -166,11 +225,12 @@ describe('inUrl Parameter', () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: false,
       status: 404,
-      statusText: 'Not Found'
+      statusText: 'Not Found',
+      headers: new Map()
     });
     global.fetch = fetchMock as typeof fetch;
 
-    // Render with inUrl parameter
+    // Render with inUrl parameter - must use allowed domain and suffix
     const testUrl = 'https://results.eval.all-hands.dev/nonexistent/results.tar.gz';
     render(
       <MemoryRouter initialEntries={[`/?inUrl=${encodeURIComponent(testUrl)}`]}>

--- a/src/test/InUrlParameter.test.tsx
+++ b/src/test/InUrlParameter.test.tsx
@@ -1,0 +1,190 @@
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import App from '../App';
+import pako from 'pako';
+
+// Helper to create a minimal tar.gz file containing output.jsonl
+function createTarGz(jsonlContent: string): Uint8Array {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(jsonlContent);
+  
+  // Create tar header for output.jsonl
+  const tarHeader = new Uint8Array(512);
+  
+  // File name (100 bytes)
+  const filename = 'output.jsonl';
+  for (let i = 0; i < filename.length; i++) {
+    tarHeader[i] = filename.charCodeAt(i);
+  }
+  
+  // File mode (8 bytes at offset 100)
+  const mode = '0000644';
+  for (let i = 0; i < mode.length; i++) {
+    tarHeader[100 + i] = mode.charCodeAt(i);
+  }
+  
+  // uid/gid (16 bytes at offset 108/116 - zeros)
+  
+  // Size in octal (12 bytes at offset 124)
+  const sizeStr = data.length.toString(8).padStart(11, '0');
+  for (let i = 0; i < sizeStr.length; i++) {
+    tarHeader[124 + i] = sizeStr.charCodeAt(i);
+  }
+  
+  // mtime (12 bytes at offset 136)
+  const mtime = Math.floor(Date.now() / 1000).toString(8).padStart(11, '0');
+  for (let i = 0; i < mtime.length; i++) {
+    tarHeader[136 + i] = mtime.charCodeAt(i);
+  }
+  
+  // Checksum placeholder - calculate after setting all other header fields
+  // (8 bytes at offset 148) - fill with spaces first
+  for (let i = 0; i < 8; i++) {
+    tarHeader[148 + i] = 0x20;
+  }
+  
+  // Type flag (1 byte at offset 156) - '0' for regular file
+  tarHeader[156] = '0'.charCodeAt(0);
+  
+  // Calculate checksum
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) {
+    checksum += tarHeader[i];
+  }
+  const checksumStr = checksum.toString(8).padStart(6, '0');
+  for (let i = 0; i < checksumStr.length; i++) {
+    tarHeader[148 + i] = checksumStr.charCodeAt(i);
+  }
+  tarHeader[154] = 0; // null terminator
+  tarHeader[155] = 0x20; // space
+  
+  // Calculate padded size (round up to 512 bytes)
+  const paddedSize = Math.ceil(data.length / 512) * 512;
+  const fileData = new Uint8Array(paddedSize);
+  fileData.set(data);
+  
+  // Create tar file with header + data + end-of-archive (1024 zeros)
+  const tar = new Uint8Array(512 + paddedSize + 1024);
+  tar.set(tarHeader);
+  tar.set(fileData, 512);
+  
+  // Compress with gzip
+  return pako.gzip(tar);
+}
+
+describe('inUrl Parameter', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    // Mock window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    // Mock localStorage
+    const mockLocalStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: mockLocalStorage,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch and load tar.gz from inUrl parameter', async () => {
+    // Create mock JSONL content
+    const jsonlContent = JSON.stringify({ instance_id: 'test-1', resolved: true }) + '\n' +
+                         JSON.stringify({ instance_id: 'test-2', resolved: false });
+    
+    // Create tar.gz data
+    const tarGzData = createTarGz(jsonlContent);
+    
+    // Mock fetch to return the tar.gz
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(tarGzData.buffer)
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    // Render with inUrl parameter
+    const testUrl = 'https://results.eval.all-hands.dev/test/results.tar.gz';
+    render(
+      <MemoryRouter initialEntries={[`/?inUrl=${encodeURIComponent(testUrl)}`]}>
+        <App router={false} />
+      </MemoryRouter>
+    );
+
+    // Wait for fetch to be called
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        testUrl,
+        expect.objectContaining({
+          mode: 'cors',
+          headers: expect.objectContaining({
+            'Accept': 'application/gzip, application/x-tar, */*'
+          })
+        })
+      );
+    });
+
+    // Wait for loading to complete and content to be processed
+    await waitFor(() => {
+      // After loading, the URL should no longer have the inUrl parameter
+      // (it gets cleared after loading)
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    }, { timeout: 5000 });
+  });
+
+  it('should handle fetch errors gracefully', async () => {
+    // Mock console.error and alert
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const alertMock = vi.fn();
+    window.alert = alertMock;
+
+    // Mock fetch to fail
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found'
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    // Render with inUrl parameter
+    const testUrl = 'https://results.eval.all-hands.dev/nonexistent/results.tar.gz';
+    render(
+      <MemoryRouter initialEntries={[`/?inUrl=${encodeURIComponent(testUrl)}`]}>
+        <App router={false} />
+      </MemoryRouter>
+    );
+
+    // Wait for error to be shown
+    await waitFor(() => {
+      expect(alertMock).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load tar.gz from URL')
+      );
+    }, { timeout: 5000 });
+
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds support for loading `results.tar.gz` files directly from a URL via the `inUrl` query parameter.

## Changes

- Added `inUrl` query parameter handling in `App.tsx`
- Fetches, decompresses (via `pako`), and extracts tar.gz archives (via `tarExtractor`)
- Shows loading overlay during fetch/processing
- Handles errors gracefully with user feedback
- Clears the URL parameter after loading to prevent reloading

## Security

- **URL validation**: Only allows URLs that:
  - Start with `https://results.eval.all-hands.dev/`
  - End with `results.tar.gz`
- **Timeout**: 60 second timeout using AbortController
- **Size limit**: Checks content-length header (max 500MB)
- **Error logging**: Logs decompression fallback attempts

## Usage

Navigate to the visualizer with a URL like:
```
https://your-visualizer.example.com/?inUrl=https://results.eval.all-hands.dev/swebench/litellm_proxy-minimax-MiniMax-M2-7/24458507797/results.tar.gz
```

The visualizer will automatically:
1. Validate the URL format
2. Fetch the tar.gz file from the provided URL
3. Decompress and extract the archive
4. Load and display the JSONL content

## Testing

Added tests in `src/test/InUrlParameter.test.tsx`:
- Verifies successful fetching and loading of tar.gz from valid URLs
- Verifies rejection of URLs from non-allowed domains
- Verifies rejection of URLs without required suffix
- Verifies error handling for failed fetches

All 16 tests pass (4 new tests for the inUrl functionality).

---

Fixes #37

_This PR was created by an AI assistant (OpenHands) on behalf of the user._