### PR TITLE
Keep inUrl parameter in URL after loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -546,8 +546,7 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
             })
             .finally(() => {
               setIsLoadingTrajectory(false);
-              // Clear the URL parameter to avoid reloading the same data
-              navigate(location.pathname, { replace: true });
+              // Keep the inUrl parameter in the URL for sharing purposes
             });
           
           return;


### PR DESCRIPTION
## Summary

Previously, the `inUrl` query parameter was cleared from the URL after loading the trajectory data. This change preserves the parameter so users can share URLs directly.

## Problem

When loading a trajectory via `inUrl` parameter like:
```
https://trajectory-visualizer.all-hands.dev/?inUrl=https://results.eval.all-hands.dev/swebench/litellm_proxy-minimax-MiniMax-M2-7/24458507797/results.tar.gz
```

The URL would change to just `https://trajectory-visualizer.all-hands.dev/` after loading, making it impossible to share the URL.

## Solution

Removed the `navigate(location.pathname, { replace: true })` call in the `.finally()` block that was clearing the URL parameters. Now the full URL including `inUrl` parameter remains visible and shareable.

## Testing

- All existing tests pass
- Build completes successfully

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/89cd7f83-1e3e-4470-96b6-59eaebbc9fc1)