### PR TITLE
Fix issue #46: Allow selection of critic output.jsonl files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -384,6 +384,7 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
         const dataParam = searchParams.get('data');
         const fileUrlParam = searchParams.get('fileUrl');
         const inUrlParam = searchParams.get('inUrl');
+        const outputFileParam = searchParams.get('outputFile');
         
         // Process embedded data parameter
         if (dataParam) {
@@ -392,6 +393,16 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
             const decodedData = atob(decodeURIComponent(dataParam));
             const parsedData = JSON.parse(decodedData);
             console.log('Found trajectory data in URL:', parsedData);
+            
+            // Apply outputFile selection if present in URL
+            if (outputFileParam && parsedData?.content?.jsonlFiles) {
+              const selectedFile = decodeURIComponent(outputFileParam);
+              if (parsedData.content.jsonlFiles[selectedFile]) {
+                parsedData.content.selectedJsonlFile = selectedFile;
+                parsedData.content.jsonlContent = parsedData.content.jsonlFiles[selectedFile];
+                console.log('Setting selected output file:', selectedFile);
+              }
+            }
             
             // Set the uploaded content
             setUploadedContent(parsedData);
@@ -521,16 +532,22 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
               }
               
               console.log('Extracting from tar...');
-              const { jsonlContent, reportContent } = extractFromTar(decompressed);
+              const { jsonlFiles, reportContent } = extractFromTar(decompressed);
               
-              if (!jsonlContent) {
+              if (Object.keys(jsonlFiles).length === 0) {
                 throw new Error('No JSONL content found in archive');
               }
+              
+              // Get the first available JSONL file for backward compatibility
+              const firstJsonlFile = Object.keys(jsonlFiles)[0];
+              const firstJsonlContent = jsonlFiles[firstJsonlFile];
               
               setUploadedContent({
                 content: {
                   fileType: 'full_archive' as const,
-                  jsonlContent,
+                  jsonlFiles,
+                  selectedJsonlFile: firstJsonlFile,
+                  jsonlContent: firstJsonlContent,
                   reportContent
                 }
               });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { BrowserRouter, Routes, Route, useParams, useNavigate, useLocation } from 'react-router-dom';
 import RepositorySelector from './components/RepositorySelector';
 import { WorkflowRunsList } from './components/workflow-runs';
@@ -362,7 +362,23 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
     const location = useLocation();
     const [uploadedContent, setUploadedContent] = useState<UploadContent | null>(null);
     const [isLoadingTrajectory, setIsLoadingTrajectory] = useState<boolean>(false);
-    
+
+    // Update the `outputFile` URL parameter when the user picks a different
+    // JSONL file in the Settings dropdown. This keeps the URL shareable.
+    const handleSelectedJsonlFileChange = useCallback((file: string) => {
+      const params = new URLSearchParams(location.search);
+      if (file) {
+        params.set('outputFile', file);
+      } else {
+        params.delete('outputFile');
+      }
+      const search = params.toString();
+      navigate(
+        { pathname: location.pathname, search: search ? `?${search}` : '' },
+        { replace: true }
+      );
+    }, [location.pathname, location.search, navigate]);
+
     // Check for URL parameters and localStorage on initial load
     useEffect(() => {
       // Keep track of load count to prevent cycles
@@ -394,12 +410,20 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
             const parsedData = JSON.parse(decodedData);
             console.log('Found trajectory data in URL:', parsedData);
             
-            // Apply outputFile selection if present in URL
-            if (outputFileParam && parsedData?.content?.jsonlFiles) {
+            // Apply outputFile selection if present in URL.
+            // Older serialised payloads may not have `jsonlFiles`, so guard
+            // for its existence and that it's a non-empty object.
+            const jsonlFiles = parsedData?.content?.jsonlFiles;
+            if (
+              outputFileParam &&
+              jsonlFiles &&
+              typeof jsonlFiles === 'object' &&
+              Object.keys(jsonlFiles).length > 0
+            ) {
               const selectedFile = decodeURIComponent(outputFileParam);
-              if (parsedData.content.jsonlFiles[selectedFile]) {
+              if (jsonlFiles[selectedFile]) {
                 parsedData.content.selectedJsonlFile = selectedFile;
-                parsedData.content.jsonlContent = parsedData.content.jsonlFiles[selectedFile];
+                parsedData.content.jsonlContent = jsonlFiles[selectedFile];
                 console.log('Setting selected output file:', selectedFile);
               }
             }
@@ -407,8 +431,14 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
             // Set the uploaded content
             setUploadedContent(parsedData);
             
-            // Clear the URL parameter to avoid reloading the same data
-            navigate(location.pathname, { replace: true });
+            // Preserve the outputFile param so the selection survives reloads/sharing
+            const preservedParams = new URLSearchParams();
+            if (outputFileParam) preservedParams.set('outputFile', outputFileParam);
+            const preservedSearch = preservedParams.toString();
+            navigate(
+              { pathname: location.pathname, search: preservedSearch ? `?${preservedSearch}` : '' },
+              { replace: true }
+            );
             return;
           } catch (error) {
             console.error('Failed to parse data parameter:', error);
@@ -756,6 +786,7 @@ const App: React.FC<{ router?: boolean }> = ({ router = true }) => {
                   workflow_name: 'Local Trajectory'
                 }}
                 initialContent={uploadedContent}
+                onSelectedJsonlFileChange={handleSelectedJsonlFileChange}
               />
             </div>
           ) : owner && repo ? (

--- a/src/components/RunDetails.tsx
+++ b/src/components/RunDetails.tsx
@@ -113,7 +113,11 @@ const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialConten
     console.log('Rendering full_archive JSONL viewer with content:', artifactContent.content.jsonlContent.substring(0, 100) + '...');
     return (
       <div className="flex flex-col h-full overflow-hidden">
-        <JsonlViewer content={artifactContent.content.jsonlContent} />
+        <JsonlViewer 
+          content={artifactContent.content.jsonlContent} 
+          jsonlFiles={artifactContent.content.jsonlFiles}
+          selectedJsonlFile={artifactContent.content.selectedJsonlFile}
+        />
       </div>
     );
   }

--- a/src/components/RunDetails.tsx
+++ b/src/components/RunDetails.tsx
@@ -12,9 +12,10 @@ interface RunDetailsProps {
   repo: string;
   run: WorkflowRun;
   initialContent?: any;
+  onSelectedJsonlFileChange?: (file: string) => void;
 }
 
-const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialContent }) => {
+const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialContent, onSelectedJsonlFileChange }) => {
   const [runDetails, setRunDetails] = useState<RunDetailsResponse | null>(null);
   const [artifactContent, setArtifactContent] = useState<any | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -117,6 +118,7 @@ const RunDetails: React.FC<RunDetailsProps> = ({ owner, repo, run, initialConten
           content={artifactContent.content.jsonlContent} 
           jsonlFiles={artifactContent.content.jsonlFiles}
           selectedJsonlFile={artifactContent.content.selectedJsonlFile}
+          onSelectedJsonlFileChange={onSelectedJsonlFileChange}
         />
       </div>
     );

--- a/src/components/jsonl-viewer/JsonlViewer.tsx
+++ b/src/components/jsonl-viewer/JsonlViewer.tsx
@@ -84,13 +84,13 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selected
     }
   }, [selectedJsonlFile, jsonlFiles]);
 
-  // Parse content when currentContent changes
+  // Parse content when currentContent or settings change
   useEffect(() => {
     try {
       const parsedEntries = parseJsonlFile(currentContent);
       setOriginalEntries(parsedEntries);
       
-      // Apply initial sorting
+      // Apply sorting when content is parsed or when settings change
       sortAndSetEntries(parsedEntries, settings);
       
       // Extract trajectory items if available
@@ -105,7 +105,7 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selected
       setError(`Failed to parse JSONL file: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentContent]);
+  }, [currentContent, settings]);
 
   // Sort entries based on settings
   const sortAndSetEntries = (entriesToSort: JsonlEntry[], currentSettings: JsonlViewerSettingsType) => {
@@ -162,7 +162,6 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selected
   // Handle settings changes
   const handleSettingsChange = (newSettings: JsonlViewerSettingsType) => {
     setSettings(newSettings);
-    sortAndSetEntries(originalEntries, newSettings);
   };
 
   const handleSelectEntry = (index: number) => {

--- a/src/components/jsonl-viewer/JsonlViewer.tsx
+++ b/src/components/jsonl-viewer/JsonlViewer.tsx
@@ -68,7 +68,6 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selected
   const [error, setError] = useState<string | null>(null);
   const [trajectoryItems, setTrajectoryItems] = useState<TrajectoryHistoryEntry[]>([]);
   const [settings, setSettings] = useState<JsonlViewerSettingsType>(DEFAULT_JSONL_VIEWER_SETTINGS);
-  const [originalEntries, setOriginalEntries] = useState<JsonlEntry[]>([]);
   const [currentContent, setCurrentContent] = useState(content);
 
   // Parse the JSONL file on component mount or when content changes
@@ -88,7 +87,6 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selected
   useEffect(() => {
     try {
       const parsedEntries = parseJsonlFile(currentContent);
-      setOriginalEntries(parsedEntries);
       
       // Apply sorting when content is parsed or when settings change
       sortAndSetEntries(parsedEntries, settings);

--- a/src/components/jsonl-viewer/JsonlViewer.tsx
+++ b/src/components/jsonl-viewer/JsonlViewer.tsx
@@ -57,20 +57,37 @@ import { TrajectoryCard } from "../share/trajectory-card";
 
 interface JsonlViewerProps {
   content: string;
+  jsonlFiles?: Record<string, string>;
+  selectedJsonlFile?: string;
 }
 
-const JsonlViewer: React.FC<JsonlViewerProps> = ({ content }) => {
+const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selectedJsonlFile }) => {
+  const availableJsonlFiles = jsonlFiles;
   const [entries, setEntries] = useState<JsonlEntry[]>([]);
   const [currentEntryIndex, setCurrentEntryIndex] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
   const [trajectoryItems, setTrajectoryItems] = useState<TrajectoryHistoryEntry[]>([]);
   const [settings, setSettings] = useState<JsonlViewerSettingsType>(DEFAULT_JSONL_VIEWER_SETTINGS);
   const [originalEntries, setOriginalEntries] = useState<JsonlEntry[]>([]);
+  const [currentContent, setCurrentContent] = useState(content);
 
   // Parse the JSONL file on component mount or when content changes
   useEffect(() => {
+    setCurrentContent(content);
+  }, [content]);
+
+  // Re-parse when selected file changes
+  useEffect(() => {
+    if (jsonlFiles && selectedJsonlFile && jsonlFiles[selectedJsonlFile]) {
+      const newContent = jsonlFiles[selectedJsonlFile];
+      setCurrentContent(newContent);
+    }
+  }, [selectedJsonlFile, jsonlFiles]);
+
+  // Parse content when currentContent changes
+  useEffect(() => {
     try {
-      const parsedEntries = parseJsonlFile(content);
+      const parsedEntries = parseJsonlFile(currentContent);
       setOriginalEntries(parsedEntries);
       
       // Apply initial sorting
@@ -88,7 +105,7 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content }) => {
       setError(`Failed to parse JSONL file: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content]);
+  }, [currentContent]);
 
   // Sort entries based on settings
   const sortAndSetEntries = (entriesToSort: JsonlEntry[], currentSettings: JsonlViewerSettingsType) => {
@@ -282,7 +299,8 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content }) => {
       {/* Settings */}
       <JsonlViewerSettings 
         settings={settings} 
-        onSettingsChange={handleSettingsChange} 
+        onSettingsChange={handleSettingsChange}
+        availableJsonlFiles={availableJsonlFiles}
       />
       
       {/* Main content with sidebar and metadata */}
@@ -292,6 +310,11 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content }) => {
           <div className="flex-none px-3 py-2 border-b border-gray-200 dark:border-gray-700">
             <h3 className="text-sm font-medium text-gray-900 dark:text-white">
               Evaluation Instances ({entries.length})
+              {settings.selectedJsonlFile && (
+                <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                  - {settings.selectedJsonlFile.split('/').pop()}
+                </span>
+              )}
             </h3>
             <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
               Sorted by: {settings.sortField} ({settings.sortDirection === 'asc' ? 'ascending' : 'descending'})

--- a/src/components/jsonl-viewer/JsonlViewer.tsx
+++ b/src/components/jsonl-viewer/JsonlViewer.tsx
@@ -59,29 +59,55 @@ interface JsonlViewerProps {
   content: string;
   jsonlFiles?: Record<string, string>;
   selectedJsonlFile?: string;
+  onSelectedJsonlFileChange?: (file: string) => void;
 }
 
-const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selectedJsonlFile }) => {
-  const availableJsonlFiles = jsonlFiles;
+const JsonlViewer: React.FC<JsonlViewerProps> = ({
+  content,
+  jsonlFiles,
+  selectedJsonlFile,
+  onSelectedJsonlFileChange,
+}) => {
   const [entries, setEntries] = useState<JsonlEntry[]>([]);
   const [currentEntryIndex, setCurrentEntryIndex] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
   const [trajectoryItems, setTrajectoryItems] = useState<TrajectoryHistoryEntry[]>([]);
-  const [settings, setSettings] = useState<JsonlViewerSettingsType>(DEFAULT_JSONL_VIEWER_SETTINGS);
+  const [settings, setSettings] = useState<JsonlViewerSettingsType>({
+    ...DEFAULT_JSONL_VIEWER_SETTINGS,
+    selectedJsonlFile,
+  });
   const [currentContent, setCurrentContent] = useState(content);
 
-  // Parse the JSONL file on component mount or when content changes
+  // Reset content baseline when the upstream content prop changes
   useEffect(() => {
     setCurrentContent(content);
   }, [content]);
 
-  // Re-parse when selected file changes
+  // Keep settings.selectedJsonlFile in sync if the upstream prop changes
+  // (e.g. a new archive is loaded with a different default file).
   useEffect(() => {
-    if (jsonlFiles && selectedJsonlFile && jsonlFiles[selectedJsonlFile]) {
-      const newContent = jsonlFiles[selectedJsonlFile];
-      setCurrentContent(newContent);
+    setSettings(prev =>
+      prev.selectedJsonlFile === selectedJsonlFile
+        ? prev
+        : { ...prev, selectedJsonlFile }
+    );
+  }, [selectedJsonlFile]);
+
+  // Switch the parsed content whenever the user picks a different file
+  // in the Settings dropdown (settings.selectedJsonlFile is the source of truth).
+  useEffect(() => {
+    const fileKey = settings.selectedJsonlFile;
+    if (jsonlFiles && fileKey && jsonlFiles[fileKey]) {
+      setCurrentContent(jsonlFiles[fileKey]);
     }
-  }, [selectedJsonlFile, jsonlFiles]);
+  }, [settings.selectedJsonlFile, jsonlFiles]);
+
+  // Notify parent so it can persist the choice (e.g. in the URL)
+  useEffect(() => {
+    if (onSelectedJsonlFileChange && settings.selectedJsonlFile !== undefined) {
+      onSelectedJsonlFileChange(settings.selectedJsonlFile);
+    }
+  }, [settings.selectedJsonlFile, onSelectedJsonlFileChange]);
 
   // Parse content when currentContent or settings change
   useEffect(() => {
@@ -297,7 +323,7 @@ const JsonlViewer: React.FC<JsonlViewerProps> = ({ content, jsonlFiles, selected
       <JsonlViewerSettings 
         settings={settings} 
         onSettingsChange={handleSettingsChange}
-        availableJsonlFiles={availableJsonlFiles}
+        availableJsonlFiles={jsonlFiles}
       />
       
       {/* Main content with sidebar and metadata */}

--- a/src/components/jsonl-viewer/JsonlViewerSettings.tsx
+++ b/src/components/jsonl-viewer/JsonlViewerSettings.tsx
@@ -7,29 +7,36 @@ import {
 export interface JsonlViewerSettingsProps {
   onSettingsChange: (settings: JsonlViewerSettings) => void;
   settings: JsonlViewerSettings;
+  availableJsonlFiles?: Record<string, string>;
 }
 
 export interface JsonlViewerSettings {
   sortField: string;
   sortDirection: 'asc' | 'desc';
   displayFields: string[];
+  selectedJsonlFile?: string;
 }
 
 const JsonlViewerSettings: React.FC<JsonlViewerSettingsProps> = ({ 
   onSettingsChange, 
-  settings 
+  settings,
+  availableJsonlFiles
 }) => {
+  const availableFiles = availableJsonlFiles ? Object.keys(availableJsonlFiles) : [];
+  const hasMultipleFiles = availableFiles.length > 1;
   const [isOpen, setIsOpen] = useState(false);
   const [sortField, setSortField] = useState(settings.sortField);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(settings.sortDirection);
   const [displayFields, setDisplayFields] = useState<string[]>(settings.displayFields);
   const [newField, setNewField] = useState('');
+  const [selectedJsonlFile, setSelectedJsonlFile] = useState(settings.selectedJsonlFile || '');
 
   const handleSave = () => {
     onSettingsChange({
       sortField,
       sortDirection,
-      displayFields
+      displayFields,
+      selectedJsonlFile: selectedJsonlFile || undefined
     });
     setIsOpen(false);
   };
@@ -90,6 +97,32 @@ const JsonlViewerSettings: React.FC<JsonlViewerSettingsProps> = ({
       {isOpen && (
         <div className="mt-2 p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-sm">
           <div className="space-y-4">
+            {/* Output File Selection - Only show if multiple files available */}
+            {hasMultipleFiles && (
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Output File</h3>
+                <div>
+                  <label htmlFor="jsonl-file" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                    Select output file to display
+                  </label>
+                  <select
+                    id="jsonl-file"
+                    value={selectedJsonlFile}
+                    onChange={(e) => setSelectedJsonlFile(e.target.value)}
+                    className="w-full px-2 py-1 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                  >
+                    <option value="">Select output file...</option>
+                    {availableFiles.map(file => (
+                      <option key={file} value={file}>{file}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Choose which output file to display. This selection is saved in the URL for sharing.
+                  </p>
+                </div>
+              </div>
+            )}
+
             {/* Sort Settings */}
             <div>
               <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Sort Entries</h3>

--- a/src/components/jsonl-viewer/JsonlViewerSettings.tsx
+++ b/src/components/jsonl-viewer/JsonlViewerSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { 
   COMMON_SORT_FIELDS, 
   COMMON_DISPLAY_FIELDS 
@@ -30,6 +30,12 @@ const JsonlViewerSettings: React.FC<JsonlViewerSettingsProps> = ({
   const [displayFields, setDisplayFields] = useState<string[]>(settings.displayFields);
   const [newField, setNewField] = useState('');
   const [selectedJsonlFile, setSelectedJsonlFile] = useState(settings.selectedJsonlFile || '');
+
+  // Keep the dropdown in sync if the selection is changed externally
+  // (e.g. via a URL parameter or when a new archive is loaded).
+  useEffect(() => {
+    setSelectedJsonlFile(settings.selectedJsonlFile || '');
+  }, [settings.selectedJsonlFile]);
 
   const handleSave = () => {
     onSettingsChange({

--- a/src/components/upload/EvaluationUpload.tsx
+++ b/src/components/upload/EvaluationUpload.tsx
@@ -33,16 +33,22 @@ export const EvaluationUpload: React.FC<EvaluationUploadProps> = ({ onUpload }) 
         }
         
         console.log('Extracting from tar...');
-        const { jsonlContent, reportContent } = extractFromTar(decompressed);
+        const { jsonlFiles, reportContent } = extractFromTar(decompressed);
         
-        if (!jsonlContent) {
+        if (Object.keys(jsonlFiles).length === 0) {
           throw new Error('No JSONL content found in archive');
         }
+        
+        // Get the first available JSONL file for backward compatibility
+        const firstJsonlFile = Object.keys(jsonlFiles)[0];
+        const firstJsonlContent = jsonlFiles[firstJsonlFile];
         
         onUpload({
           content: {
             fileType: 'full_archive' as const,
-            jsonlContent,
+            jsonlFiles,
+            selectedJsonlFile: firstJsonlFile,
+            jsonlContent: firstJsonlContent,
             reportContent
           }
         });

--- a/src/config/jsonl-viewer-config.ts
+++ b/src/config/jsonl-viewer-config.ts
@@ -26,5 +26,6 @@ export const COMMON_DISPLAY_FIELDS: string[] = [
 export const DEFAULT_JSONL_VIEWER_SETTINGS = {
   sortField: 'instance_id',
   sortDirection: 'asc' as const,
-  displayFields: [...COMMON_DISPLAY_FIELDS]
+  displayFields: [...COMMON_DISPLAY_FIELDS],
+  selectedJsonlFile: undefined as string | undefined
 };

--- a/src/lib/__tests__/tarExtractor.test.ts
+++ b/src/lib/__tests__/tarExtractor.test.ts
@@ -65,7 +65,7 @@ describe('extractFromTar', () => {
     ]);
     
     const result = extractFromTar(tar);
-    expect(result.jsonlContent).toBe('{"instance_id":"test1"}\n{"instance_id":"test2"}');
+    expect(result.jsonlFiles['eval_results/output.jsonl']).toBe('{"instance_id":"test1"}\n{"instance_id":"test2"}');
     expect(result.reportContent).toBeNull();
   });
 
@@ -75,7 +75,7 @@ describe('extractFromTar', () => {
     ]);
     
     const result = extractFromTar(tar);
-    expect(result.jsonlContent).toBeNull();
+    expect(Object.keys(result.jsonlFiles).length).toBe(0);
     expect(result.reportContent).toEqual({ total: 10, passed: 8 });
   });
 
@@ -86,7 +86,7 @@ describe('extractFromTar', () => {
     ]);
     
     const result = extractFromTar(tar);
-    expect(result.jsonlContent).toBe('{"instance_id":"test"}');
+    expect(result.jsonlFiles['eval_results/output.jsonl']).toBe('{"instance_id":"test"}');
     expect(result.reportContent).toEqual({ total: 1 });
   });
 
@@ -97,13 +97,13 @@ describe('extractFromTar', () => {
     ]);
     
     const result = extractFromTar(tar);
-    expect(result.jsonlContent).toBe('main content');
+    expect(result.jsonlFiles['eval_results/output.jsonl']).toBe('main content');
   });
 
-  it('returns null for empty archive', () => {
+  it('returns empty object for empty archive', () => {
     const tar = createTar([]);
     const result = extractFromTar(tar);
-    expect(result.jsonlContent).toBeNull();
+    expect(Object.keys(result.jsonlFiles).length).toBe(0);
     expect(result.reportContent).toBeNull();
   });
 
@@ -119,6 +119,22 @@ describe('extractFromTar', () => {
     ]);
     
     const result = extractFromTar(tar);
-    expect(result.jsonlContent).toBeNull(); // Empty content not matched
+    expect(Object.keys(result.jsonlFiles).length).toBe(0); // Empty content not matched
+  });
+
+  it('extracts critic_attempt files', () => {
+    const tar = createTar([
+      { name: 'eval_results/output.jsonl', content: 'main content' },
+      { name: 'eval_results/output.critic_attempt_1.jsonl', content: 'critic 1' },
+      { name: 'eval_results/output.critic_attempt_2.jsonl', content: 'critic 2' },
+      { name: 'eval_results/output.critic_attempt_3.jsonl', content: 'critic 3' },
+    ]);
+    
+    const result = extractFromTar(tar);
+    expect(Object.keys(result.jsonlFiles).length).toBe(4);
+    expect(result.jsonlFiles['eval_results/output.jsonl']).toBe('main content');
+    expect(result.jsonlFiles['eval_results/output.critic_attempt_1.jsonl']).toBe('critic 1');
+    expect(result.jsonlFiles['eval_results/output.critic_attempt_2.jsonl']).toBe('critic 2');
+    expect(result.jsonlFiles['eval_results/output.critic_attempt_3.jsonl']).toBe('critic 3');
   });
 });

--- a/src/lib/tarExtractor.ts
+++ b/src/lib/tarExtractor.ts
@@ -44,15 +44,17 @@ function parseTarHeader(data: Uint8Array, offset: number): { name: string; size:
 }
 
 /**
- * Extract output.jsonl and output.report.json from a tar.gz archive.
+ * Extract all output.jsonl files and output.report.json from a tar.gz archive.
  * Validates archive size and handles malformed entries gracefully.
+ * Returns a map of JSONL file names to their content.
  */
-export function extractFromTar(data: Uint8Array): { jsonlContent: string | null; reportContent: any | null } {
+export function extractFromTar(data: Uint8Array): { jsonlFiles: Record<string, string>; reportContent: any | null } {
   const blockSize = 512;
   let offset = 0;
   let pendingLongName: string | null = null;
-  let jsonlContent: string | null = null;
+  const jsonlFiles: Record<string, string> = {};
   let reportContent: any | null = null;
+  let hasPrimaryOutput = false;
   let largestJsonlSize = 0;
 
   while (offset + blockSize <= data.length) {
@@ -71,18 +73,33 @@ export function extractFromTar(data: Uint8Array): { jsonlContent: string | null;
         pendingLongName = null;
         const lowerName = fileName.toLowerCase();
 
-        // Match output.jsonl (main results) - exclude auxiliary files
+        // Match output.jsonl files - include main output and critic_attempt files
         const isJsonl = lowerName.endsWith('/output.jsonl') || 
                         lowerName === 'output.jsonl' ||
-                        (lowerName.includes('output.jsonl') && !lowerName.includes('errors') && !lowerName.includes('cost') && !lowerName.includes('timeline') && !lowerName.includes('critic'));
+                        lowerName.endsWith('/output.critic_attempt_1.jsonl') ||
+                        lowerName === 'output.critic_attempt_1.jsonl' ||
+                        lowerName.endsWith('/output.critic_attempt_2.jsonl') ||
+                        lowerName === 'output.critic_attempt_2.jsonl' ||
+                        lowerName.endsWith('/output.critic_attempt_3.jsonl') ||
+                        lowerName === 'output.critic_attempt_3.jsonl';
         const isReport = lowerName.includes('output.report.json') || (lowerName.includes('report') && lowerName.endsWith('.json'));
 
         if (isJsonl || isReport) {
           const content = new TextDecoder('utf8').decode(data.slice(offset, offset + header.size));
           
-          if (isJsonl && header.size > largestJsonlSize) {
-            jsonlContent = content;
-            largestJsonlSize = header.size;
+          if (isJsonl) {
+            // Store each JSONL file with its name as the key
+            jsonlFiles[fileName] = content;
+            
+            // Track largest output.jsonl
+            if (header.size > largestJsonlSize) {
+              largestJsonlSize = header.size;
+            }
+            
+            // Check if this is the primary output.jsonl (not a critic file)
+            if (!hasPrimaryOutput && !lowerName.includes('critic')) {
+              hasPrimaryOutput = true;
+            }
           }
           if (isReport) {
             try {
@@ -97,20 +114,23 @@ export function extractFromTar(data: Uint8Array): { jsonlContent: string | null;
       offset += paddedSize;
     }
 
-    // Early exit if we found both files with sufficient content
-    if (jsonlContent && reportContent && largestJsonlSize > 100000) {
-      break;
+    // Early exit if we found the main output.jsonl, any critic files, and report with sufficient content
+    if (hasPrimaryOutput && reportContent && largestJsonlSize > 100000) {
+      // Continue to find critic files if there might be more
+      if (Object.keys(jsonlFiles).length >= 4) {
+        break;
+      }
     }
   }
 
-  return { jsonlContent, reportContent };
+  return { jsonlFiles, reportContent };
 }
 
 /**
  * Decompress and extract data from a tar.gz archive.
  * Validates size and throws for oversized files.
  */
-export async function decompressTarGz(data: Uint8Array): Promise<{ jsonlContent: string | null; reportContent: any | null }> {
+export async function decompressTarGz(data: Uint8Array): Promise<{ jsonlFiles: Record<string, string>; reportContent: any | null }> {
   if (data.length > MAX_ARCHIVE_SIZE) {
     throw new Error(`Archive too large: ${(data.length / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_ARCHIVE_SIZE / 1024 / 1024}MB limit`);
   }

--- a/src/lib/tarExtractor.ts
+++ b/src/lib/tarExtractor.ts
@@ -54,8 +54,10 @@ export function extractFromTar(data: Uint8Array): { jsonlFiles: Record<string, s
   let pendingLongName: string | null = null;
   const jsonlFiles: Record<string, string> = {};
   let reportContent: any | null = null;
-  let hasPrimaryOutput = false;
-  let largestJsonlSize = 0;
+
+  // Matches `output.jsonl` or `output.critic_attempt_N.jsonl` (any N),
+  // either at the top level or nested under a directory.
+  const jsonlPattern = /(?:^|\/)output(?:\.critic_attempt_\d+)?\.jsonl$/;
 
   while (offset + blockSize <= data.length) {
     const header = parseTarHeader(data, offset);
@@ -73,33 +75,15 @@ export function extractFromTar(data: Uint8Array): { jsonlFiles: Record<string, s
         pendingLongName = null;
         const lowerName = fileName.toLowerCase();
 
-        // Match output.jsonl files - include main output and critic_attempt files
-        const isJsonl = lowerName.endsWith('/output.jsonl') || 
-                        lowerName === 'output.jsonl' ||
-                        lowerName.endsWith('/output.critic_attempt_1.jsonl') ||
-                        lowerName === 'output.critic_attempt_1.jsonl' ||
-                        lowerName.endsWith('/output.critic_attempt_2.jsonl') ||
-                        lowerName === 'output.critic_attempt_2.jsonl' ||
-                        lowerName.endsWith('/output.critic_attempt_3.jsonl') ||
-                        lowerName === 'output.critic_attempt_3.jsonl';
+        const isJsonl = jsonlPattern.test(lowerName);
         const isReport = lowerName.includes('output.report.json') || (lowerName.includes('report') && lowerName.endsWith('.json'));
 
         if (isJsonl || isReport) {
           const content = new TextDecoder('utf8').decode(data.slice(offset, offset + header.size));
-          
+
           if (isJsonl) {
             // Store each JSONL file with its name as the key
             jsonlFiles[fileName] = content;
-            
-            // Track largest output.jsonl
-            if (header.size > largestJsonlSize) {
-              largestJsonlSize = header.size;
-            }
-            
-            // Check if this is the primary output.jsonl (not a critic file)
-            if (!hasPrimaryOutput && !lowerName.includes('critic')) {
-              hasPrimaryOutput = true;
-            }
           }
           if (isReport) {
             try {
@@ -112,14 +96,6 @@ export function extractFromTar(data: Uint8Array): { jsonlFiles: Record<string, s
       }
 
       offset += paddedSize;
-    }
-
-    // Early exit if we found the main output.jsonl, any critic files, and report with sufficient content
-    if (hasPrimaryOutput && reportContent && largestJsonlSize > 100000) {
-      // Continue to find critic files if there might be more
-      if (Object.keys(jsonlFiles).length >= 4) {
-        break;
-      }
     }
   }
 

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -12,7 +12,9 @@ export interface TrajectoryUploadContent {
 }
 
 export interface FullArchiveUploadContent {
-  jsonlContent: string;
+  jsonlFiles?: Record<string, string>;
+  selectedJsonlFile?: string;
+  jsonlContent?: string;
   reportContent?: any;
   fileType: 'full_archive';
 }

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -12,8 +12,15 @@ export interface TrajectoryUploadContent {
 }
 
 export interface FullArchiveUploadContent {
-  jsonlFiles?: Record<string, string>;
+  /** All JSONL files extracted from the archive, keyed by file name. */
+  jsonlFiles: Record<string, string>;
+  /** Currently selected file (key into `jsonlFiles`). */
   selectedJsonlFile?: string;
+  /**
+   * Content of the currently selected JSONL file.
+   * Kept for backward compatibility with consumers that don't yet use
+   * `jsonlFiles` / `selectedJsonlFile`.
+   */
   jsonlContent?: string;
   reportContent?: any;
   fileType: 'full_archive';


### PR DESCRIPTION
## Summary

This PR implements the feature requested in issue #46 - allowing users to select between different output.jsonl files when viewing evaluation results.

### Changes Made:

1. **Updated tarExtractor.ts**: Modified to extract all available JSONL files (output.jsonl, output.critic_attempt_1.jsonl, output.critic_attempt_2.jsonl, output.critic_attempt_3.jsonl) from tar.gz archives instead of only the main output.jsonl.

2. **Added JSONL file selection in Settings UI**: Added a dropdown in the Settings panel that only appears when multiple output files are available. Users can select which file to display.

3. **URL parameter support**: Added the `outputFile` URL parameter to make the selection shareable. When sharing a URL, the selected output file is preserved.

4. **Display selected file name**: Shows the name of the selected output file under the "Evaluation Instances (N)" header.

5. **Updated components**: Modified JsonlViewer, JsonlViewerSettings, RunDetails, EvaluationUpload, and App.tsx to support handling multiple JSONL files.

6. **Added tests**: Added a new test case for critic_attempt file extraction in tarExtractor.test.ts.

### How it works:

- When uploading or loading a results.tar.gz file, all available JSONL files are extracted
- The Settings button now has an "Output File" dropdown (only visible if multiple files exist)
- Selecting a different file updates the view immediately
- The selected file is shown in the URL for sharing

Closes #46

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/afd807a9-3975-4f85-8962-64bd3ee03c92)